### PR TITLE
Introduce templates for scalar and timeseries resources

### DIFF
--- a/results/_resources/_scalar_template.csv
+++ b/results/_resources/_scalar_template.csv
@@ -1,0 +1,1 @@
+id_scal;scenario;name;var_name;carrier;region;tech;type;var_value;var_unit;reference;comment

--- a/results/_resources/_timeseries_template.csv
+++ b/results/_resources/_timeseries_template.csv
@@ -1,0 +1,1 @@
+id_ts;region;var_name;timeindex_start;timeindex_stop;timeindex_resolution;series;var_unit;source;comment


### PR DESCRIPTION
This PR introduces a unified format for scalar and timeseries data for oemof-B3.

We put the templates in results/_resources because they define the target format for all data that is to be preprocessed from raw data. Raw data may come from different sources in different formats. If raw data means data that is collected within the project, we are free to set it up in the template format already.

The scalar format is very close to the format of the DataPackages that are finally optimized by oemof.solph. 

The timeseries format is stacked such that each line is one timeseries. This makes it easy to address timeseries and exchange them depending on the scenario.

In general, the format is related to the oedatamodel and could be mapped back and forth.