### PR TITLE
Add reference to header of scalars.csv 

### DIFF
--- a/oemof_b3/schema/scalars.csv
+++ b/oemof_b3/schema/scalars.csv
@@ -1,1 +1,1 @@
-id_scal;scenario;name;var_name;carrier;region;tech;type;var_value;var_unit;source;comment
+id_scal;scenario;name;var_name;carrier;region;tech;type;var_value;var_unit;source;reference;comment


### PR DESCRIPTION
Added "reference" to header of 'scalars.csv'  in directory `schema`.

This came up in #35. I got a ValueError because of "extra columns": `ValueError: There are extra columns ['reference']`
If "reference" stays in 'scalars.csv' this PR should be merged into `dev`.