### PR TITLE
Not include index_name in header

### DIFF
--- a/oemof_b3/tools/data_processing.py
+++ b/oemof_b3/tools/data_processing.py
@@ -54,24 +54,26 @@ def format_header(df, header, index_name):
     -------
     df_formatted : pd.DataFrame
     """
-    extra_colums = get_list_diff(df.columns, header)
+    _df = df.copy()
+
+    extra_colums = get_list_diff(_df.columns, header)
 
     if index_name in extra_colums:
-        df = df.set_index(index_name, drop=True)
-        extra_colums = get_list_diff(df.columns, header)
+        _df = _df.set_index(index_name, drop=True)
+        extra_colums = get_list_diff(_df.columns, header)
     else:
-        df.index.name = index_name
+        _df.index.name = index_name
 
     if extra_colums:
         raise ValueError(f"There are extra columns {extra_colums}")
 
-    missing_columns = get_list_diff(header, df.columns)
+    missing_columns = get_list_diff(header, _df.columns)
 
     for col in missing_columns:
-        df[col] = np.nan
+        _df[col] = np.nan
 
     try:
-        df_formatted = df[header]
+        df_formatted = _df[header]
 
     except KeyError:
         raise KeyError("Failed to format data according to specified header.")


### PR DESCRIPTION
The function format header's docstring claims that `header` is a list of columns. However, as of now it expects the index name to appear in the list as well. This is confusing, as `index_name` is a separate argument of the function.

This PR fixes the bug by adapting the function such that it expects column names. If the index_name is in the columns of `df`, it sets it as the index. If not, it uses the existing index and gives it the name `index_name`. Accordingly, the `HEADER_B3_SCAL` and `HEADER_B3_TS` do not include the index name any more.