### PR TITLE
Unify resource names

### DIFF
--- a/Snakefile
+++ b/Snakefile
@@ -100,14 +100,6 @@ rule prepare_scalars:
     shell:
         "python {input.script} {input.raw_scalars} {output}"
 
-rule build_datapackage:
-    input:
-        "scenarios/{scenario}.yml"
-    output:
-        directory("results/{scenario}/preprocessed")
-    shell:
-        "python scripts/build_datapackage.py {input} {output}"
-
 rule prepare_re_potential:
     input:
         pv_agriculture="raw/area_potential/2021-05-18_pv_agriculture_brandenburg_kreise_epsg32633.csv",
@@ -130,6 +122,14 @@ rule process_re_potential:
         table="results/_tables/potential_wind_pv_kreise.csv",
     shell:
         "python {input.script} {input.input_dir} {output.scalars} {output.table}"
+
+rule build_datapackage:
+    input:
+        "scenarios/{scenario}.yml"
+    output:
+        directory("results/{scenario}/preprocessed")
+    shell:
+        "python scripts/build_datapackage.py {input} {output}"
 
 rule optimize:
     input:

--- a/Snakefile
+++ b/Snakefile
@@ -87,7 +87,7 @@ rule prepare_electricity_demand:
                             keep_local=True),
         script="scripts/prepare_electricity_demand.py"
     output:
-        "results/_resources/load_profile_electricity.csv"
+        "results/_resources/ts_load_electricity.csv"
     shell:
         "python {input.script} {input.opsd_url} {output}"
 

--- a/Snakefile
+++ b/Snakefile
@@ -9,7 +9,7 @@ examples = [
 
 scenario_list_example = ['examples']
 
-resources = ['conv_pp_scalar']
+resources = ['scal_conv_pp']
 
 scenarios = ["toy-scenario", "toy-scenario-2"]
 
@@ -66,7 +66,7 @@ rule prepare_conv_pp:
         b3_regions="raw/b3_regions.yaml",
         script="scripts/prepare_conv_pp.py"
     output:
-        "results/_resources/conv_pp_scalar.csv"
+        "results/_resources/scal_conv_pp.csv"
     shell:
         "python scripts/prepare_conv_pp.py {input.opsd} {input.gpkg} {input.b3_regions} {output}"
 

--- a/Snakefile
+++ b/Snakefile
@@ -118,7 +118,7 @@ rule process_re_potential:
         input_dir=directory("results/_resources/RE_potential/"),
         script="scripts/process_re_potential.py"
     output:
-        scalars="results/_resources/wind_pv_scalar.csv",
+        scalars="results/_resources/scal_power_potential_wind_pv.csv",
         table="results/_tables/potential_wind_pv_kreise.csv",
     shell:
         "python {input.script} {input.input_dir} {output.scalars} {output.table}"

--- a/Snakefile
+++ b/Snakefile
@@ -77,7 +77,7 @@ rule prepare_feedin:
         ror_feedin="raw/time_series/DIW_Hydro_availability.csv",
         script="scripts/prepare_feedin.py"
     output:
-        "results/_resources/feedin_time_series.csv"
+        "results/_resources/ts_feedin.csv"
     shell:
         "python {input.script} {input.wind_feedin} {input.pv_feedin} {input.ror_feedin} {output}"
 

--- a/Snakefile
+++ b/Snakefile
@@ -93,7 +93,7 @@ rule prepare_electricity_demand:
 
 rule prepare_scalars:
     input:
-        raw_scalars="raw/scal_base-scenario.csv",
+        raw_scalars="raw/base-scenario.csv",
         script="scripts/prepare_scalars.py",
     output:
         "results/_resources/scal_base-scenario.csv"

--- a/Snakefile
+++ b/Snakefile
@@ -93,10 +93,10 @@ rule prepare_electricity_demand:
 
 rule prepare_scalars:
     input:
-        raw_scalars="raw/base-scenario.csv",
+        raw_scalars="raw/scal_base-scenario.csv",
         script="scripts/prepare_scalars.py",
     output:
-        "results/_resources/base-scenario.csv"
+        "results/_resources/scal_base-scenario.csv"
     shell:
         "python {input.script} {input.raw_scalars} {output}"
 

--- a/oemof_b3/tools/data_processing.py
+++ b/oemof_b3/tools/data_processing.py
@@ -102,6 +102,10 @@ def load_b3_scalars(path, sep=","):
 
     df = format_header(df, HEADER_B3_SCAL, "id_scal")
 
+    df.loc[:, "var_value"] = df.loc[:, "var_value"].apply(
+        lambda x: ast.literal_eval(x), 1
+    )
+
     return df
 
 

--- a/oemof_b3/tools/data_processing.py
+++ b/oemof_b3/tools/data_processing.py
@@ -98,13 +98,13 @@ def load_b3_scalars(path, sep=","):
         DataFrame with loaded scalars
     """
     # Read data
-    df = pd.read_csv(path, sep=sep, dtype={"var_value": str})
+    df = pd.read_csv(path, sep=sep)
+
+    df["var_value"] = pd.to_numeric(df["var_value"], errors="coerce").fillna(
+        df["var_value"]
+    )
 
     df = format_header(df, HEADER_B3_SCAL, "id_scal")
-
-    df.loc[:, "var_value"] = df.loc[:, "var_value"].apply(
-        lambda x: ast.literal_eval(x), 1
-    )
 
     return df
 

--- a/oemof_b3/tools/data_processing.py
+++ b/oemof_b3/tools/data_processing.py
@@ -98,7 +98,7 @@ def load_b3_scalars(path, sep=","):
         DataFrame with loaded scalars
     """
     # Read data
-    df = pd.read_csv(path, sep=sep)
+    df = pd.read_csv(path, sep=sep, dtype={"var_value": str})
 
     df = format_header(df, HEADER_B3_SCAL, "id_scal")
 

--- a/scripts/prepare_conv_pp.py
+++ b/scripts/prepare_conv_pp.py
@@ -13,7 +13,7 @@ in_path3 : str
 in_path4 : str
     ``oemof_b3/schema/scalars.csv``: path of template for scalar data as .csv
 out_path : str
-    ``results/_resources/conv_pp_scalar.csv``: path of output file with prepared data as .csv
+    ``results/_resources/scal_conv_pp.csv``: path of output file with prepared data as .csv
 
 Outputs
 ---------

--- a/scripts/prepare_electricity_demand.py
+++ b/scripts/prepare_electricity_demand.py
@@ -5,7 +5,7 @@ Inputs
 opsd_ts_data : str
     raw opsd timeseries data including electricty load as .csv
 output_file : str
-    ``results/_resources/load_profile_electricity.csv``: path of output file with prepared
+    ``results/_resources/ts_load_electricity.csv``: path of output file with prepared
     data as .csv
 
 Outputs

--- a/scripts/prepare_feedin.py
+++ b/scripts/prepare_feedin.py
@@ -11,7 +11,7 @@ filename_pv : str
 filename_for : str
     ``raw/time_series/DIW_Hydro_availability.csv``:
 output_file : str
-    ``results/_resources/feedin_time_series.csv``:
+    ``results/_resources/ts_feedin.csv``:
 
 Outputs
 ---------

--- a/scripts/prepare_scalars.py
+++ b/scripts/prepare_scalars.py
@@ -3,9 +3,10 @@ r"""
 Inputs
 -------
 in_path1 : str
-    path incl. file name of input file with raw scalar data as .csv
+    ``raw/scal_base-scenario.csv``: path incl. file name of input file with raw scalar data as .csv
 out_path : str
-    path incl. file name of output file with prepared scalar data as .csv
+    ``results/_resources/scal_base-scenario.csv``: path incl. file name of output file with prepared
+    scalar data as .csv
 
 Outputs
 ---------

--- a/scripts/process_re_potential.py
+++ b/scripts/process_re_potential.py
@@ -5,8 +5,8 @@ Inputs
 input_dir : str
     ``results/_resources/RE_potential/``: Path to input directory of renewable potential
 output_scalars : str
-    ``results/_resources/wind_pv_scalar.csv``: Path incl. file name to scalar output as input to
-    energy system model
+    ``results/_resources/scal_power_potential_wind_pv.csv``: Path incl. file name to scalar output
+    as input to energy system model
 output_tables : str
     ``results/_tables/potential_wind_pv_kreise.csv``: Path incl. file name to output for results
     documentation

--- a/tests/_files/oemof_b3_resources_scalars_mixed_types.csv
+++ b/tests/_files/oemof_b3_resources_scalars_mixed_types.csv
@@ -1,0 +1,6 @@
+scenario,name,var_name,carrier,region,tech,type,var_value,comment
+base,BE-biomass-st,capacity,biomass,BE,gt,conversion,1,int
+base,BB-biomass-st,capacity,biomass,BB,gt,conversion,1.,float
+base,BB-biomass-st,flow_in_biomass,biomass,BB,gt,conversion,True,bool
+base,BE-biomass-st,flow_in_biomass,biomass,BE,gt,conversion,profile,str
+base,BB-biomass-st,flow_out_electricity,biomass,BB,gt,conversion,{"extra_argument": 1},dict

--- a/tests/test_data_processing.py
+++ b/tests/test_data_processing.py
@@ -23,6 +23,12 @@ path_file_sc = os.path.join(
     "oemof_b3_resources_scalars.csv",
 )
 
+path_file_sc_mixed_types = os.path.join(
+    os.path.abspath(os.path.join(this_path, os.pardir)),
+    "_files",
+    "oemof_b3_resources_scalars_mixed_types.csv",
+)
+
 path_file_ts_stacked = os.path.join(
     os.path.abspath(os.path.join(this_path, os.pardir)),
     "_files",
@@ -89,6 +95,21 @@ def test_load_b3_scalars():
 
     for col in sc_cols_list:
         assert col in df_cols
+
+
+def test_load_b3_scalars_mixed_types():
+    """
+    This test checks whether the entries in "var_value" have the correct types.
+    """
+
+    df = load_b3_scalars(path_file_sc_mixed_types)
+
+    types = [type(value) for value in df["var_value"]]
+
+    # could more strictly assert that types are [int, float, bool, str, dict] as soon as this is
+    # needed.
+
+    assert types == [float, float, str, str, str], f"Types are {types}"
 
 
 def test_load_b3_timeseries():


### PR DESCRIPTION
This PR unifies the names of the resources according to the convention:

`ts/scal_<general_description>_<details>.csv`

I did not change `prepare_re_potential` because I do not know if I this applies to all files in `RE_potential`. Can you give your feedback @SabineHaas?