### PR TITLE
Fix bullet points rendering by adding "sphinx-rtd-theme>=0.5.1" to "install_requires"

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -20,6 +20,7 @@ setup(
         "pyyaml",
         "snakemake",
         "oemoflex @ git+https://git@github.com/rl-institut/oemoflex@dev#egg=oemoflex",
+        "sphinx-rtd-theme>=0.5.1",
     ],
     extras_require={"dev": ["pytest", "black==20.8b1", "coverage", "flake8"]},
 )


### PR DESCRIPTION
Resolves #61 

With this PR the incorrect rendering of bullet points in the docs is fixed by specifying the `sphinx-rtd-theme` version as mentioned in https://github.com/rl-institut/oemof-B3/issues/61#issuecomment-914218741. 

The bullet point rendering was tested in the following rtd version: [fix-docs-bullet-point-rendering](https://oemof-b3.readthedocs.io/en/fix-docs-bullet-point-rendering/). 