### PR TITLE
Fixes/connect snakemake dag

### DIFF
--- a/Snakefile
+++ b/Snakefile
@@ -115,7 +115,7 @@ rule prepare_re_potential:
 
 rule process_re_potential:
     input:
-        input_dir=directory("results/_resources/RE_potential/"),
+        input_dir="results/_resources/RE_potential/",
         script="scripts/process_re_potential.py"
     output:
         scalars="results/_resources/scal_power_potential_wind_pv.csv",

--- a/Snakefile
+++ b/Snakefile
@@ -125,11 +125,15 @@ rule process_re_potential:
 
 rule build_datapackage:
     input:
-        "scenarios/{scenario}.yml"
+        scalars = "results/_resources/scal_base-scenario.csv",
+        power_potential_re="results/_resources/scal_power_potential_wind_pv.csv",
+        feedin="results/_resources/ts_feedin.csv",
+        load_electricity="results/_resources/ts_load_electricity.csv",
+        scenario="scenarios/{scenario}.yml",
     output:
         directory("results/{scenario}/preprocessed")
     shell:
-        "python scripts/build_datapackage.py {input} {output}"
+        "python scripts/build_datapackage.py {input.scenario} {output}"
 
 rule optimize:
     input:

--- a/Snakefile
+++ b/Snakefile
@@ -20,7 +20,7 @@ rule plot_grouped_scenarios:
 
 rule plot_all_scenarios:
     input:
-        expand("results/{scenario}/plotted/", scenario=examples)
+        expand("results/{scenario}/plotted/", scenario=scenarios)
 
 rule run_all_examples:
     input:


### PR DESCRIPTION
This PR introduces some fixes of the DAG defined in the snakefile. You can check the DAG visually by plotting it, e.g.: `snakemake --dag plot_all_scenarios | dot -Tsvg > dag.svg`

TODO/Done
* [x] plot_all_scenarios: Obsolete (should change examples to scenarios
* [ ] plot_grouped_scenarios: DAG starts only after joining scalar results
* [ ] plot_all_resources does not work: missing input file
* [ ] is the rule clean useful as it is?