### PR TITLE
Add missing excess/shortage components

### DIFF
--- a/oemof_b3/config/labels.yml
+++ b/oemof_b3/config/labels.yml
@@ -18,7 +18,10 @@ hydro-ror: Hydro ROR
 solar-pv: PV
 wind-onshore: Wind on
 h2-bpchp: H2 Backpressure CHP
-ch4-excess: CH4 Excess
+ch4-excess: CH4 Export
+ch4-shortage: CH4 Import
+h2-excess: H2 Export
+h2-shortage: H2 Import
 heat_central-excess: Heat cen. excess
 heat_central-storage: Heat cen. storage
 heat_central-shortage: Heat cen. shortage

--- a/oemof_b3/config/labels.yml
+++ b/oemof_b3/config/labels.yml
@@ -18,10 +18,10 @@ hydro-ror: Hydro ROR
 solar-pv: PV
 wind-onshore: Wind on
 h2-bpchp: H2 Backpressure CHP
-ch4-excess: CH4 Export
-ch4-shortage: CH4 Import
-h2-excess: H2 Export
-h2-shortage: H2 Import
+ch4-export: CH4 Export
+ch4-import: CH4 Import
+h2-export: H2 Export
+h2-import: H2 Import
 heat_central-excess: Heat cen. excess
 heat_central-storage: Heat cen. storage
 heat_central-shortage: Heat cen. shortage

--- a/oemof_b3/model/bus_attrs_update.yml
+++ b/oemof_b3/model/bus_attrs_update.yml
@@ -1,11 +1,15 @@
 h2:
   balanced:
-    False
+    True
 
 heat_central:
   balanced:
     True
 
 heat_decentral:
+  balanced:
+    True
+
+ch4:
   balanced:
     True

--- a/oemof_b3/model/component_attrs_update.yml
+++ b/oemof_b3/model/component_attrs_update.yml
@@ -60,6 +60,7 @@ heat_central-excess:
     bus: heat_central
   defaults:
     marginal_cost: 0
+    input_parameters: "{}"
 
 heat_central-shortage:
   carrier: heat_central
@@ -96,6 +97,7 @@ heat_decentral-excess:
     bus: heat_decentral
   defaults:
     marginal_cost: 0
+    input_parameters: "{}"
 
 heat_decentral-shortage:
   carrier: heat_decentral

--- a/oemof_b3/model/component_attrs_update.yml
+++ b/oemof_b3/model/component_attrs_update.yml
@@ -6,27 +6,37 @@ ch4-demand:
     bus: ch4
     profile: ch4-demand-profile
 
-ch4-shortage:
+ch4-import:
   carrier: ch4
-  tech: shortage
+  tech: import
   type: shortage
   foreign_keys:
     bus: ch4
   defaults:
     output_parameters: "{}"
 
-h2-shortage:
+ch4-export:
+  carrier: ch4
+  tech: export
+  type: excess
+  foreign_keys:
+    bus: ch4
+  defaults:
+    marginal_cost: 0
+    input_parameters: "{}"
+
+h2-import:
   carrier: h2
-  tech: shortage
+  tech: import
   type: shortage
   foreign_keys:
     bus: h2
   defaults:
     output_parameters: "{}"
 
-h2-excess:
+h2-export:
   carrier: h2
-  tech: excess
+  tech: export
   type: excess
   foreign_keys:
     bus: h2

--- a/oemof_b3/model/component_attrs_update.yml
+++ b/oemof_b3/model/component_attrs_update.yml
@@ -15,6 +15,25 @@ ch4-shortage:
   defaults:
     output_parameters: "{}"
 
+h2-shortage:
+  carrier: h2
+  tech: shortage
+  type: shortage
+  foreign_keys:
+    bus: h2
+  defaults:
+    output_parameters: "{}"
+
+h2-excess:
+  carrier: h2
+  tech: excess
+  type: excess
+  foreign_keys:
+    bus: h2
+  defaults:
+    marginal_cost: 0
+    output_parameters: "{}"
+
 electricity-electrolyzer:
   carrier: electricity
   tech: electrolyzer

--- a/oemof_b3/model/component_attrs_update.yml
+++ b/oemof_b3/model/component_attrs_update.yml
@@ -32,7 +32,7 @@ h2-excess:
     bus: h2
   defaults:
     marginal_cost: 0
-    output_parameters: "{}"
+    input_parameters: "{}"
 
 electricity-electrolyzer:
   carrier: electricity

--- a/oemof_b3/model/foreign_keys_update.yml
+++ b/oemof_b3/model/foreign_keys_update.yml
@@ -1,8 +1,9 @@
 'bus': [
     'ch4-demand',
-    'ch4-shortage',
-    'h2-shortage',
-    'h2-excess',
+    'ch4-import',
+    'ch4-export',
+    'h2-import',
+    'h2-export',
     'heat_central-shortage',
     'heat_central-excess',
     'heat_central-demand',

--- a/oemof_b3/model/foreign_keys_update.yml
+++ b/oemof_b3/model/foreign_keys_update.yml
@@ -1,6 +1,8 @@
 'bus': [
     'ch4-demand',
     'ch4-shortage',
+    'h2-shortage',
+    'h2-excess',
     'heat_central-shortage',
     'heat_central-excess',
     'heat_central-demand',

--- a/scenarios/base-scenario.yml
+++ b/scenarios/base-scenario.yml
@@ -25,8 +25,8 @@ components:
   - ch4-boiler
   - ch4-bpchp
   - ch4-demand
-  - ch4-excess
-  - ch4-shortage
+  - ch4-export
+  - ch4-import
   - ch4-gt
   - electricity-demand
   - electricity-electrolyzer
@@ -36,8 +36,8 @@ components:
   - electricity-shortage
   - h2-gt
   - h2-bpchp
-  - h2-excess
-  - h2-shortage
+  - h2-export
+  - h2-import
   - heat_central-demand
   - heat_central-excess
   - heat_central-shortage

--- a/scenarios/base-scenario.yml
+++ b/scenarios/base-scenario.yml
@@ -35,6 +35,8 @@ components:
   - electricity-shortage
   - h2-gt
   - h2-bpchp
+  - h2-excess
+  - h2-shortage
   - heat_central-demand
   - heat_central-excess
   - heat_central-shortage

--- a/scenarios/base-scenario.yml
+++ b/scenarios/base-scenario.yml
@@ -26,6 +26,7 @@ components:
   - ch4-bpchp
   - ch4-demand
   - ch4-excess
+  - ch4-shortage
   - ch4-gt
   - electricity-demand
   - electricity-electrolyzer


### PR DESCRIPTION
Changes in this PR:

1. Busses `h2` and `ch4` are balanced (set to True in `bus_attrs_update.yml`), as we are working with excess (export) and shortage (import) components.
2. Add h2 shortage and h2 excess (model/, labels.yml)
3. Add h2 and ch4 shortage and h2 excess to our base scenario 
4. Change label of ch4-excess to "CH4 Export" instead of "CH4 Excess"

@jnnr 1. also solves the issue of excess components not being displayed in results. 
I am not sure why they were not displayed while the busses were unbalanced. Seems like excess component of a bus is neglected (in oemoflex?) if the bus is unbalanced. I did not check further.

Needs oemoflex branch `fix/defaults_of_excess` (https://github.com/rl-institut/oemoflex/pull/48)
and `raw/base-scenario_PR107.csv`

I gave the `marginal_cost` of `excess` the dummy value 0 in the csv. Later we add negative costs (earn money by export). Is this correct @jnnr or is this value processed an thus should be positive?