### PR TITLE
Fix components in toy-scenario YAML files

### DIFF
--- a/scenarios/toy-scenario-2.yml
+++ b/scenarios/toy-scenario-2.yml
@@ -25,8 +25,8 @@ components:
   - ch4-boiler
   - ch4-bpchp
   - ch4-demand
-  - ch4-shortage
-  - ch4-excess
+  - ch4-export
+  - ch4-import
   - ch4-gt
   - electricity-demand
   - electricity-electrolyzer
@@ -36,6 +36,8 @@ components:
   - electricity-shortage
   - h2-gt
   - h2-bpchp
+  - h2-export
+  - h2-import
   - heat_central-demand
   - heat_central-excess
   - heat_central-shortage

--- a/scenarios/toy-scenario.yml
+++ b/scenarios/toy-scenario.yml
@@ -25,8 +25,8 @@ components:
   - ch4-boiler
   - ch4-bpchp
   - ch4-demand
-  - ch4-shortage
-  - ch4-excess
+  - ch4-export
+  - ch4-import
   - ch4-gt
   - electricity-demand
   - electricity-electrolyzer
@@ -36,6 +36,8 @@ components:
   - electricity-shortage
   - h2-gt
   - h2-bpchp
+  - h2-export
+  - h2-import
   - heat_central-demand
   - heat_central-excess
   - heat_central-shortage


### PR DESCRIPTION
This PR is a fix of labels which are missing and are not correct among `components` in these files:

- toy-scenario.yml
- toy-scenario-2.yml

They were forgotten merging the PR https://github.com/rl-institut/oemof-B3/pull/107.
