### PR TITLE
Feature/use consistent timeindex

### DIFF
--- a/scenarios/base-scenario.yml
+++ b/scenarios/base-scenario.yml
@@ -5,6 +5,14 @@
 
 name: base-scenario
 
+datetimeindex:
+  start:
+    "2019-01-01"
+  freq:
+    "H"
+  periods:
+    8760
+
 regions:
   - BB
   - B

--- a/scenarios/base-scenario.yml
+++ b/scenarios/base-scenario.yml
@@ -50,6 +50,14 @@ components:
   - solar-pv
   - wind-onshore
 
+datetimeindex:
+  start:
+    "2019-01-01"
+  freq:
+    "H"
+  periods:
+    8760
+
 # parametrize
 
 path_scalars: results/_resources/scal_base-scenario.csv

--- a/scenarios/toy-scenario-2.yml
+++ b/scenarios/toy-scenario-2.yml
@@ -5,6 +5,14 @@
 
 name: toy-scenario-2
 
+datetimeindex:
+  start:
+    "2019-01-01"
+  freq:
+    "H"
+  periods:
+    8760
+
 regions:
   - BB
   - B

--- a/scenarios/toy-scenario.yml
+++ b/scenarios/toy-scenario.yml
@@ -5,6 +5,14 @@
 
 name: toy-scenario
 
+datetimeindex:
+  start:
+    "2019-01-01"
+  freq:
+    "H"
+  periods:
+    8760
+
 regions:
   - BB
   - B

--- a/scripts/build_datapackage.py
+++ b/scripts/build_datapackage.py
@@ -224,7 +224,11 @@ if __name__ == "__main__":
     scenario_specs = load_yaml(scenario_specs)
 
     # setup empty EnergyDataPackage
-    datetimeindex = pd.date_range(start="2019-01-01", freq="H", periods=8760)
+    datetimeindex = pd.date_range(
+        start=scenario_specs["datetimeindex"]["start"],
+        freq=scenario_specs["datetimeindex"]["freq"],
+        periods=scenario_specs["datetimeindex"]["periods"],
+    )
 
     # setup default structure
     edp = EnergyDataPackage.setup_default(

--- a/scripts/create_empty_scalars.py
+++ b/scripts/create_empty_scalars.py
@@ -93,7 +93,11 @@ if __name__ == "__main__":
     scenario_specs = load_yaml(scenario_specs)
 
     # setup empty EnergyDataPackage
-    datetimeindex = pd.date_range(start="2019-01-01", freq="H", periods=8760)
+    datetimeindex = pd.date_range(
+        start=scenario_specs["datetimeindex"]["start"],
+        freq=scenario_specs["datetimeindex"]["freq"],
+        periods=scenario_specs["datetimeindex"]["periods"],
+    )
 
     # setup default structure
     edp = EnergyDataPackage.setup_default(

--- a/scripts/plot_dispatch.py
+++ b/scripts/plot_dispatch.py
@@ -88,7 +88,7 @@ if __name__ == "__main__":
         # plot one winter and one summer month
         # select timeframe
         start_date_data = str(data.index[0])
-        end_date_data = str(data.index[31*24-1])
+        end_date_data = str(data.index[31 * 24 - 1])
         timeframe = [
             (start_date_data, end_date_data),
             (

--- a/scripts/plot_dispatch.py
+++ b/scripts/plot_dispatch.py
@@ -43,12 +43,6 @@ if __name__ == "__main__":
     bus_directory = os.path.join(postprocessed, "sequences/bus/")
     bus_files = os.listdir(bus_directory)
 
-    # select timeframe
-    timeframe = [
-        ("2019-01-01 00:00:00", "2019-01-31 23:00:00"),
-        ("2019-07-01 00:00:00", "2019-07-31 23:00:00"),
-    ]
-
     # select carrier
     carriers = ["electricity", "heat_central", "heat_decentral"]
 
@@ -92,6 +86,16 @@ if __name__ == "__main__":
 
         # normal dispatch plot
         # plot one winter and one summer month
+        # select timeframe
+        start_date_data = str(data.index[0])
+        end_date_data = str(data.index[31*24-1])
+        timeframe = [
+            (start_date_data, end_date_data),
+            (
+                start_date_data.replace("01-", "07-"),
+                end_date_data.replace("01-", "07-"),
+            ),
+        ]
         for start_date, end_date in timeframe:
             fig, ax = plt.subplots(figsize=(12, 5))
 

--- a/scripts/plot_dispatch.py
+++ b/scripts/plot_dispatch.py
@@ -87,15 +87,12 @@ if __name__ == "__main__":
         # normal dispatch plot
         # plot one winter and one summer month
         # select timeframe
-        start_date_data = str(data.index[0])
-        end_date_data = str(data.index[31 * 24 - 1])
+        year = data.index[0].year
         timeframe = [
-            (start_date_data, end_date_data),
-            (
-                start_date_data.replace("01-", "07-"),
-                end_date_data.replace("01-", "07-"),
-            ),
+            (f"{year}-01-01 00:00:00", f"{year}-01-31 23:00:00"),
+            (f"{year}-07-01 00:00:00", f"{year}-07-31 23:00:00"),
         ]
+
         for start_date, end_date in timeframe:
             fig, ax = plt.subplots(figsize=(12, 5))
 


### PR DESCRIPTION
This PR resolves issue #111

In this PR hardcoded datetimeindex is replaced by dataspecific one.

For the two files:
- `create_empty_scalars.py` and
- `build_datapackage.py`
a datetimeindex is used from the YAML-file `base-scenario.yml`.

In
- `plot_dispatch.py`
the datetimeindex is collected from the plotted data.

Procedure in line with the above is still needed for:
- `prepare_feedin.py`