### PR TITLE
Results tables

### DIFF
--- a/Snakefile
+++ b/Snakefile
@@ -202,6 +202,14 @@ rule postprocess:
     shell:
         "python scripts/postprocess.py {input} {wildcards.scenario} {output} {params.logfile}"
 
+rule create_results_table:
+    input:
+        "results/{scenario}/postprocessed/"
+    output:
+        directory("results/{scenario}/tables/")
+    shell:
+        "python scripts/create_results_table.py {input} {output}"
+
 rule plot_dispatch:
     input:
         "results/{scenario}/postprocessed/"

--- a/oemof_b3/tools/data_processing.py
+++ b/oemof_b3/tools/data_processing.py
@@ -620,6 +620,24 @@ def stack_var_name(df):
     return stacked
 
 
+def round_setting_int(df, decimals):
+    r"""
+    Rounds the columns of a DataFrame to the specified decimals. For zero decimals,
+    it changes the dtype to Int64. Tolerates NaNs.
+    """
+    _df = df.copy()
+
+    for col, dec in decimals.items():
+        if dec == 0:
+            dtype = "Int64"
+        else:
+            dtype = float
+
+        _df[col] = pd.to_numeric(_df[col], errors="coerce").round(dec).astype(dtype)
+
+    return _df
+
+
 class ScalarProcessor:
     r"""
     This class allows to filter and unstack scalar data in a way that makes processing simpler.

--- a/oemof_b3/tools/data_processing.py
+++ b/oemof_b3/tools/data_processing.py
@@ -269,6 +269,8 @@ def aggregate_scalars(df, columns_to_aggregate, agg_method=None):
     """
     _df = df.copy()
 
+    _df = format_header(_df, HEADER_B3_SCAL, "id_scal")
+
     if not isinstance(columns_to_aggregate, list):
         columns_to_aggregate = [columns_to_aggregate]
 

--- a/oemof_b3/tools/data_processing.py
+++ b/oemof_b3/tools/data_processing.py
@@ -628,7 +628,10 @@ def round_setting_int(df, decimals):
     _df = df.copy()
 
     for col, dec in decimals.items():
-        if dec == 0:
+        if col not in _df.columns:
+            print(f"No column named '{col}' found when trying to round.")
+            continue
+        elif dec == 0:
             dtype = "Int64"
         else:
             dtype = float

--- a/scripts/create_input_data_overview.py
+++ b/scripts/create_input_data_overview.py
@@ -21,7 +21,7 @@ import sys
 import pandas as pd
 
 from oemof_b3 import labels_dict
-from oemof_b3.tools.data_processing import load_b3_scalars
+import oemof_b3.tools.data_processing as dp
 
 SCENARIO_KEY = "Base 2050"
 REGION = "ALL"
@@ -43,7 +43,7 @@ if __name__ == "__main__":
     in_path = sys.argv[1]  # input data
     out_path = sys.argv[2]
 
-    df = load_b3_scalars(in_path)
+    df = dp.load_b3_scalars(in_path)
 
     # filter for data within the scenario key defined above
     df = df.loc[df["scenario_key"] == SCENARIO_KEY]
@@ -95,24 +95,7 @@ if __name__ == "__main__":
     df.set_index("Technology", inplace=True, drop=True)
     df = df.sort_index()
 
-    def round_setting_int(df, decimals):
-        r"""
-        Rounds the columns of a DataFrame to the specified decimals. For zero decimals,
-        it changes the dtype to Int64. Tolerates NaNs.
-        """
-        _df = df.copy()
-
-        for col, dec in decimals.items():
-            if dec == 0:
-                dtype = "Int64"
-            else:
-                dtype = float
-
-            _df[col] = pd.to_numeric(_df[col], errors="coerce").round(dec).astype(dtype)
-
-        return _df
-
-    df = round_setting_int(df, DECIMALS)
+    df = dp.round_setting_int(df, DECIMALS)
 
     # save
     df.to_csv(out_path)

--- a/scripts/create_results_table.py
+++ b/scripts/create_results_table.py
@@ -33,56 +33,58 @@ def unstack_var_name(df):
     return _df.unstack("var_name")
 
 
+def create_production_table(scalars, carrier):
+    VAR_NAMES = [
+        "capacity",
+        f"invest_out_{carrier}",
+        f"flow_out_{carrier}",
+        "storage_capacity",
+        "invest",
+        "loss",
+    ]
+
+    df = scalars.copy()
+
+    # df = dp.aggregate_scalars(df, "region")
+
+    df = dp.filter_df(df, "var_name", VAR_NAMES)
+
+    df = unstack_var_name(df).loc[:, "var_value"]
+
+    df = df.loc[~df[f"flow_out_{carrier}"].isna()]
+
+    df.index = df.index.droplevel(["name", "scenario", "type"])
+
+    df.loc[:, "FLH"] = df.loc[:, f"flow_out_{carrier}"] / df.loc[
+        :, ["capacity", "invest"]
+    ].sum(axis=1)
+
+    return df
+
+
+def create_demand_table(scalars):
+    df = scalars.copy()
+
+    var_name = "flow_in_"
+
+    # df = dp.aggregate_scalars(df, "region")
+
+    df = df.loc[df["var_name"].str.contains(var_name)]
+
+    df = dp.filter_df(df, "type", ["excess", "load"])
+
+    df = df.set_index(["region", "carrier", "tech"])
+
+    df = df.loc[:, ["var_name", "var_value"]]
+
+    return df
+
+
 if __name__ == "__main__":
     in_path = sys.argv[1]  # input data
     out_path = sys.argv[2]
 
     scalars = pd.read_csv(os.path.join(in_path, "scalars.csv"))
-
-    def create_production_table(scalars, carrier):
-        VAR_NAMES = [
-            "capacity",
-            f"invest_out_{carrier}",
-            f"flow_out_{carrier}",
-            "storage_capacity",
-            "invest",
-            "loss",
-        ]
-
-        df = scalars.copy()
-
-        # df = dp.aggregate_scalars(df, "region")
-
-        df = dp.filter_df(df, "var_name", VAR_NAMES)
-
-        df = unstack_var_name(df).loc[:, "var_value"]
-
-        df = df.loc[~df[f"flow_out_{carrier}"].isna()]
-
-        df.index = df.index.droplevel(["name", "scenario", "type"])
-
-        df.loc[:, "FLH"] = df.loc[:, f"flow_out_{carrier}"] / df.loc[
-            :, ["capacity", "invest"]
-        ].sum(axis=1)
-
-        return df
-
-    def create_demand_table(scalars):
-        df = scalars.copy()
-
-        var_name = "flow_in_"
-
-        # df = dp.aggregate_scalars(df, "region")
-
-        df = df.loc[df["var_name"].str.contains(var_name)]
-
-        df = dp.filter_df(df, "type", ["excess", "load"])
-
-        df = df.set_index(["region", "carrier", "tech"])
-
-        df = df.loc[:, ["var_name", "var_value"]]
-
-        return df
 
     if not os.path.exists(out_path):
         os.makedirs(out_path)

--- a/scripts/create_results_table.py
+++ b/scripts/create_results_table.py
@@ -46,7 +46,7 @@ def create_production_table(scalars, carrier):
     df.index = df.index.droplevel(["name", "scenario_key", "type"])
 
     df.loc[:, "FLH"] = df.loc[:, f"flow_out_{carrier}"] / df.loc[
-        :, ["capacity", "invest"]
+        :, ["capacity", f"invest_out_{carrier}"]
     ].sum(axis=1)
 
     df = dp.round_setting_int(df, decimals={col: 0 for col in df.columns})

--- a/scripts/create_results_table.py
+++ b/scripts/create_results_table.py
@@ -89,8 +89,13 @@ if __name__ == "__main__":
     if not os.path.exists(out_path):
         os.makedirs(out_path)
 
-    df = create_production_table(scalars, "electricity")
-    dp.save_df(df, os.path.join(out_path, "production_table.csv"))
+    for carrier in ["electricity", "heat_central", "heat_decentral", "h2"]:
+        try:
+            df = create_production_table(scalars, carrier)
+            dp.save_df(df, os.path.join(out_path, f"production_table_{carrier}.csv"))
+        except:  # noqa E722
+            print(f"Could not create production table for carrier {carrier}.")
+            continue
 
     df = create_demand_table(scalars)
     dp.save_df(df, os.path.join(out_path, "sink_table.csv"))

--- a/scripts/create_results_table.py
+++ b/scripts/create_results_table.py
@@ -59,6 +59,8 @@ def create_production_table(scalars, carrier):
         :, ["capacity", "invest"]
     ].sum(axis=1)
 
+    df = dp.round_setting_int(df, decimals={col: 0 for col in df.columns})
+
     return df
 
 
@@ -73,9 +75,11 @@ def create_demand_table(scalars):
 
     df = dp.filter_df(df, "type", ["excess", "load"])
 
-    df = df.set_index(["region", "carrier", "tech"])
+    df = df.set_index(["region", "carrier", "tech", "var_name"])
 
     df = df.loc[:, ["var_name", "var_value"]]
+
+    df = dp.round_setting_int(df, decimals={col: 0 for col in df.columns})
 
     return df
 

--- a/scripts/create_results_table.py
+++ b/scripts/create_results_table.py
@@ -25,7 +25,8 @@ import oemof_b3.tools.data_processing as dp
 if __name__ == "__main__":
     in_path = sys.argv[1]  # input data
     out_path = sys.argv[2]
-    scalars = pd.read_csv(in_path)
+
+    scalars = pd.read_csv(os.path.join(in_path, "scalars.csv"))
 
     def create_production_table(scalars, carrier):
         VAR_NAMES = [
@@ -69,8 +70,11 @@ if __name__ == "__main__":
 
         return df
 
+    if not os.path.exists(out_path):
+        os.makedirs(out_path)
+
     df = create_production_table(scalars, "electricity")
-    df.to_csv(os.path.join(out_path, "production_table.csv"))
+    dp.save_df(df, os.path.join(out_path, "production_table.csv"))
 
     df = create_demand_table(scalars)
-    df.to_csv(os.path.join(out_path, "sink_table.csv"))
+    dp.save_df(df, os.path.join(out_path, "sink_table.csv"))

--- a/scripts/create_results_table.py
+++ b/scripts/create_results_table.py
@@ -22,6 +22,17 @@ import pandas as pd
 
 import oemof_b3.tools.data_processing as dp
 
+
+def unstack_var_name(df):
+    _df = df.copy()
+
+    _df = df.set_index(
+        ["scenario", "name", "region", "carrier", "tech", "type", "var_name"]
+    )
+
+    return _df.unstack("var_name")
+
+
 if __name__ == "__main__":
     in_path = sys.argv[1]  # input data
     out_path = sys.argv[2]
@@ -44,7 +55,7 @@ if __name__ == "__main__":
 
         df = dp.filter_df(df, "var_name", VAR_NAMES)
 
-        df = dp.unstack_var_name(df).loc[:, "var_value"]
+        df = unstack_var_name(df).loc[:, "var_value"]
 
         df = df.loc[~df[f"flow_out_{carrier}"].isna()]
 

--- a/scripts/create_results_table.py
+++ b/scripts/create_results_table.py
@@ -70,7 +70,7 @@ def create_demand_table(scalars):
 
     df = df.set_index(["region", "carrier", "tech", "var_name"])
 
-    df = df.loc[:, ["var_name", "var_value"]]
+    df = df.loc[:, ["var_value"]]
 
     df = dp.round_setting_int(df, decimals={col: 0 for col in df.columns})
 

--- a/scripts/create_results_table.py
+++ b/scripts/create_results_table.py
@@ -1,0 +1,76 @@
+# coding: utf-8
+r"""
+Inputs
+------
+in_path : str
+    ``results/{scenario}/postprocessed/scalars.csv``: path to scalar results.
+out_path : str
+    ``results/{scenario}/tables/``: target path for results tables.
+
+Outputs
+-------
+.csv
+    Tables showing results.
+
+Description
+-----------
+"""
+import os
+import sys
+
+import pandas as pd
+
+import oemof_b3.tools.data_processing as dp
+
+if __name__ == "__main__":
+    in_path = sys.argv[1]  # input data
+    out_path = sys.argv[2]
+    scalars = pd.read_csv(in_path)
+
+    def create_production_table(scalars, carrier):
+        VAR_NAMES = [
+            "capacity",
+            f"flow_out_{carrier}",
+            "storage_capacity",
+            "invest",
+            "loss",
+        ]
+
+        df = scalars.copy()
+
+        # df = dp.aggregate_scalars(df, "region")
+
+        df = dp.filter_df(df, "var_name", VAR_NAMES)
+
+        df = dp.unstack_var_name(df).loc[:, "var_value"]
+
+        df = df.loc[~df[f"flow_out_{carrier}"].isna()]
+
+        df.index = df.index.droplevel(["name", "scenario", "type"])
+
+        df["FLH"] = df[f"flow_out_{carrier}"] / (df["capacity"] + df["invest"])
+
+        return df
+
+    def create_demand_table(scalars):
+        df = scalars.copy()
+
+        var_name = "flow_in_"
+
+        # df = dp.aggregate_scalars(df, "region")
+
+        df = df.loc[df["var_name"].str.contains(var_name)]
+
+        df = dp.filter_df(df, "type", ["excess", "load"])
+
+        df = df.set_index(["region", "carrier", "tech"])
+
+        df = df.loc[:, ["var_name", "var_value"]]
+
+        return df
+
+    df = create_production_table(scalars, "electricity")
+    df.to_csv(os.path.join(out_path, "production_table.csv"))
+
+    df = create_demand_table(scalars)
+    df.to_csv(os.path.join(out_path, "sink_table.csv"))

--- a/scripts/create_results_table.py
+++ b/scripts/create_results_table.py
@@ -31,6 +31,7 @@ if __name__ == "__main__":
     def create_production_table(scalars, carrier):
         VAR_NAMES = [
             "capacity",
+            f"invest_out_{carrier}",
             f"flow_out_{carrier}",
             "storage_capacity",
             "invest",

--- a/scripts/create_results_table.py
+++ b/scripts/create_results_table.py
@@ -18,6 +18,7 @@ Description
 import os
 import sys
 
+import numpy as np
 import pandas as pd
 
 import oemof_b3.tools.data_processing as dp
@@ -48,6 +49,8 @@ def create_production_table(scalars, carrier):
     df.loc[:, "FLH"] = df.loc[:, f"flow_out_{carrier}"] / df.loc[
         :, ["capacity", f"invest_out_{carrier}"]
     ].sum(axis=1)
+
+    df.replace({np.inf: np.nan}, inplace=True)
 
     df = dp.round_setting_int(df, decimals={col: 0 for col in df.columns})
 

--- a/scripts/create_results_table.py
+++ b/scripts/create_results_table.py
@@ -49,7 +49,9 @@ if __name__ == "__main__":
 
         df.index = df.index.droplevel(["name", "scenario", "type"])
 
-        df["FLH"] = df[f"flow_out_{carrier}"] / (df["capacity"] + df["invest"])
+        df.loc[:, "FLH"] = df.loc[:, f"flow_out_{carrier}"] / df.loc[
+            :, ["capacity", "invest"]
+        ].sum(axis=1)
 
         return df
 


### PR DESCRIPTION
This PR introduces two tables that give an overview over results. The tables look like this:

production_table

|                                         | capacity   |   flow_out_electricity | invest    | invest_out_electricity   | storage_capacity   | FLH   |
|:----------------------------------------|:-----------|-----------------------:|:----------|:-------------------------|:-------------------|:------|
| ('All', 'biomass', 'gt')                | 400000     |             1023260210 | <NA>      | <NA>                     | <NA>               | 2558  |
| ('All', 'electricity', 'liion_battery') | 0          |             7785780022 | 319195215 | 7076739                  | 0                  | 1100  |
| ('All', 'electricity', 'shortage')      | <NA>       |                      0 | <NA>      | <NA>                     | <NA>               | <NA>  |
| ('All', 'oil', 'gt')                    | 300000     |              185370699 | <NA>      | <NA>                     | <NA>               | 618   |
| ('All', 'solar', 'pv')                  | 11700000   |            11136807166 | <NA>      | <NA>                     | <NA>               | 952   |
| ('All', 'wind', 'onshore')              | 9900000    |            30548425047 | <NA>      | <NA>                     | <NA>               | 3086  |

sink_table

|                                                              |   var_value |
|:-------------------------------------------------------------|------------:|
| ('All', 'electricity', 'curtailment', 'flow_in_electricity') |  6665918045 |
| ('All', 'electricity', 'demand', 'flow_in_electricity')      | 33727320000 |
