### PR TITLE
Fix/demandlib installation advise

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ In order to install oemof-B3 locally, following steps must be made:
 Oemof-B3 needs pandoc (version > 2) in order to create reports. Pandoc is included in conda environment config (environment.yml). 
 If environment is build otherwise, pandoc must be installed manually. It can be installed following instructions from [Pandoc Installation](https://pandoc.org/installing.html).
 
-Oemof-B3 further needs demandlib in order to create heat load profiles. Due to an conflict of required pandas versions,
+Oemof-B3 further needs demandlib in order to create heat load profiles. Due to a conflict of required pandas versions,
 the demandlib cannot be installed with `poetry install`. A separate installation is therefore necessary:
 
     pip install demandlib

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ In order to install oemof-B3 locally, following steps must be made:
 Oemof-B3 needs pandoc (version > 2) in order to create reports. Pandoc is included in conda environment config (environment.yml). 
 If environment is build otherwise, pandoc must be installed manually. It can be installed following instructions from [Pandoc Installation](https://pandoc.org/installing.html).
 
-Oemof-B3 further needs demandlib in order to create heat load profiles. Due to an alleged clash of pandas versions,
+Oemof-B3 further needs demandlib in order to create heat load profiles. Due to an conflict of required pandas versions,
 the demandlib cannot be installed with `poetry install`. A separate installation is therefore necessary:
 
     pip install demandlib

--- a/README.md
+++ b/README.md
@@ -43,6 +43,13 @@ In order to install oemof-B3 locally, following steps must be made:
 Oemof-B3 needs pandoc (version > 2) in order to create reports. Pandoc is included in conda environment config (environment.yml). 
 If environment is build otherwise, pandoc must be installed manually. It can be installed following instructions from [Pandoc Installation](https://pandoc.org/installing.html).
 
+Oemof-B3 further needs demandlib in order to create heat load profiles. Due to an alleged clash of pandas versions,
+the demandlib cannot be installed with `poetry install`. A separate installation is therefore necessary:
+
+    pip install demandlib
+
+The clash of the pandas version should be fixed with the release of oemof-B3 0.0.2.
+
 Please activate pre-commit hooks (via `pre-commit install`) in order to follow our coding styles.
 
 ### Data

--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -18,6 +18,8 @@ Installation
 
 You can install oemof-B3 in your environment via pip.
 
+::
+
     pip install oemof-B3
 
 As oemof-B3 is under development, it might be better to install the current dev branch locally. See

--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -41,6 +41,15 @@ In order to install oemof-B3 locally, following steps must be made:
 Oemof-B3 needs pandoc (version > 2) in order to create reports. Pandoc is included in conda environment config (environment.yml).
 If environment is build otherwise, pandoc must be installed manually. It can be installed following instructions from [Pandoc Installation](https://pandoc.org/installing.html).
 
+Oemof-B3 further needs demandlib in order to create heat load profiles. Due to an alleged clash of pandas versions,
+the demandlib cannot be installed with `poetry install`. A separate installation is therefore necessary:
+
+::
+
+    pip install demandlib
+
+The clash of the pandas version should be fixed with the release of oemof-B3 0.0.2.
+
 Please activate pre-commit hooks (via `pre-commit install`) in order to follow our coding styles.
 
 Required: An LP-solver


### PR DESCRIPTION
Resolves #167 

This PR gives an explanation on how to install the `demandlib` and records the basic problem along with the prospect of a fix, which should be within the release of oemof-B3 0.0.2, since `oemof.tabular` should soon work with `oemof.solph` instead of the old `oemof`.