### PR TITLE
Scenario handling for time series

### DIFF
--- a/scenarios/base-2050-high_capacity_cost.yml
+++ b/scenarios/base-2050-high_capacity_cost.yml
@@ -105,4 +105,7 @@ paths_timeseries:
 
 filter_timeseries:
   scenario_key:
-    ts_2017
+    - "Base 2050"
+    - "ALL"
+  timeindex_start:
+    "2017-01-01 00:00:00"

--- a/scenarios/base-2050.yml
+++ b/scenarios/base-2050.yml
@@ -93,4 +93,7 @@ paths_timeseries:
 
 filter_timeseries:
   scenario_key:
-    ts_2017
+    - "Base 2050"
+    - "ALL"
+  timeindex_start:
+    "2017-01-01 00:00:00"

--- a/scenarios/high-2050.yml
+++ b/scenarios/high-2050.yml
@@ -93,5 +93,8 @@ paths_timeseries:
 
 filter_timeseries:
   scenario_key:
-    ts_2017
+    - "Base 2050"
+    - "ALL"
+  timeindex_start:
+    "2017-01-01 00:00:00"
 

--- a/scenarios/low-2050.yml
+++ b/scenarios/low-2050.yml
@@ -101,5 +101,7 @@ paths_timeseries:
 
 filter_timeseries:
   scenario_key:
-    ts_2017
-
+    - "Base 2050"
+    - "ALL"
+  timeindex_start:
+    "2017-01-01 00:00:00"

--- a/scripts/prepare_electricity_demand.py
+++ b/scripts/prepare_electricity_demand.py
@@ -84,7 +84,9 @@ def prepare_load_profile_time_series(ts_raw, year, region):
     ts_prepared.loc[:, "var_name"] = "electricity-demand-profile"
     ts_prepared.loc[:, "source"] = TS_SOURCE
     ts_prepared.loc[:, "comment"] = TS_COMMENT
-    ts_prepared.loc[:, "scenario_key"] = f"ts_{year}"
+    ts_prepared.loc[
+        :, "scenario_key"
+    ] = "ALL"  # The profile is not varied in different scenarios
 
     return ts_prepared
 

--- a/scripts/prepare_feedin.py
+++ b/scripts/prepare_feedin.py
@@ -157,7 +157,7 @@ def prepare_ror_time_series(filename_ts, region):
         ts_prepared = dp.format_header(
             df=ts_stacked, header=dp.HEADER_B3_TS, index_name="id_ts"
         )
-        ts_prepared.loc[:, "scenario_key"] = f"ts_{year}"
+        ts_prepared.loc[:, "scenario_key"] = "ALL"
         ts_df = pd.concat([ts_df, ts_prepared])
 
     # add additional information as required by template

--- a/scripts/prepare_feedin.py
+++ b/scripts/prepare_feedin.py
@@ -91,7 +91,9 @@ def prepare_wind_and_pv_time_series(filename_ts, year, type):
     ts_prepared.loc[:, "var_name"] = f"{type}-profile"
     ts_prepared.loc[:, "source"] = TS_SOURCE
     ts_prepared.loc[:, "comment"] = TS_COMMENT
-    ts_prepared.loc[:, "scenario_key"] = f"ts_{year}"
+    ts_prepared.loc[
+        :, "scenario_key"
+    ] = "ALL"  # The profile is not varied in different scenarios
 
     return ts_prepared
 

--- a/scripts/prepare_heat_demand.py
+++ b/scripts/prepare_heat_demand.py
@@ -106,7 +106,7 @@ def find_regional_files(path, region):
     files_region : list
         List of file names matching region
     """
-    files_region = [file for file in os.listdir(path) if region in file]
+    files_region = [file for file in os.listdir(path) if f"_{region}_" in file]
     files_region = sorted(files_region)
 
     if not files_region:

--- a/scripts/prepare_heat_demand.py
+++ b/scripts/prepare_heat_demand.py
@@ -495,7 +495,11 @@ if __name__ == "__main__":
                 carrier, holidays, temperature, yearly_demands, building_class
             )
             total_heat_load = postprocess_data(
-                total_heat_load, heat_load_year, region, f"ts_{year}", sc_demand_unit
+                total_heat_load,
+                heat_load_year,
+                region,
+                scenario,
+                sc_demand_unit,
             )
     # aggregate heat demand for different sectors (hh, ghd, i)
     demand_per_sector = dp.filter_df(

--- a/scripts/prepare_vehicle_charging_demand.py
+++ b/scripts/prepare_vehicle_charging_demand.py
@@ -114,9 +114,11 @@ def prepare_vehicle_charging_demand(input_dir, balanced=True):
         ts_total_norm = ts_total_demand / ts_total_demand.sum()
 
         # stack time series and add region
-        ts_stacked = dp.stack_timeseries(ts_total_norm).rename(
-            columns={"var_name": "scenario_key"}
-        )
+        ts_stacked = dp.stack_timeseries(ts_total_norm)
+
+        # The profile is not varied in different scenarios
+        ts_stacked.loc[:, "scenario_key"] = "ALL"
+
         ts_stacked.loc[:, "region"] = region
 
         # add to `df`

--- a/tests/_files/oemof_b3_resources_timeseries_elec_vehicle_demand.csv
+++ b/tests/_files/oemof_b3_resources_timeseries_elec_vehicle_demand.csv
@@ -1,3 +1,3 @@
 id_ts;scenario_key;region;var_name;timeindex_start;timeindex_stop;timeindex_resolution;series;var_unit;source;comment
-0;ts_2019;BB;electricity-bev_charging-profile;2019-01-01 00:00:00;2019-01-01 02:00:00;H;"[0.36641573208006967, 0.33080598089020347, 0.30277828702972687]";None;created with simBEV;https://github.com/rl-institut/simbev
-1;ts_2015;B;electricity-bev_charging-profile;2015-01-01 00:00:00;2015-01-01 02:00:00;H;"[0.3709718013655691, 0.3303502017829303, 0.2986779968515006]";None;created with simBEV;https://github.com/rl-institut/simbev
+0;ALL;BB;electricity-bev_charging-profile;2019-01-01 00:00:00;2019-01-01 02:00:00;H;"[0.36641573208006967, 0.33080598089020347, 0.30277828702972687]";None;created with simBEV;https://github.com/rl-institut/simbev
+1;ALL;B;electricity-bev_charging-profile;2015-01-01 00:00:00;2015-01-01 02:00:00;H;"[0.3709718013655691, 0.3303502017829303, 0.2986779968515006]";None;created with simBEV;https://github.com/rl-institut/simbev

--- a/tests/_files/oemof_b3_resources_timeseries_feedin.csv
+++ b/tests/_files/oemof_b3_resources_timeseries_feedin.csv
@@ -1,5 +1,5 @@
 id_ts;scenario_key;region;var_name;timeindex_start;timeindex_stop;timeindex_resolution;series;var_unit;source;comment
-0;ts_2012;B;wind-profile;2012-01-01 10:00:00;2012-01-01 12:00:00;H;"[0.1593, 0.2175, 0.2113]";None;https://www.renewables.ninja/;navigate to country Germany
-1;ts_2012;BB;wind-profile;2012-01-01 10:00:00;2012-01-01 12:00:00;H;"[0.2299, 0.2635, 0.2866]";None;https://www.renewables.ninja/;navigate to country Germany
-0;ts_2012;B;pv-profile;2012-01-01 10:00:00;2012-01-01 12:00:00;H;"[0.013, 0.018, 0.011]";None;https://www.renewables.ninja/;navigate to country Germany
-1;ts_2012;BB;pv-profile;2012-01-01 10:00:00;2012-01-01 12:00:00;H;"[0.015, 0.019, 0.012]";None;https://www.renewables.ninja/;navigate to country Germany
+0;ALL;B;wind-profile;2012-01-01 10:00:00;2012-01-01 12:00:00;H;"[0.1593, 0.2175, 0.2113]";None;https://www.renewables.ninja/;navigate to country Germany
+1;ALL;BB;wind-profile;2012-01-01 10:00:00;2012-01-01 12:00:00;H;"[0.2299, 0.2635, 0.2866]";None;https://www.renewables.ninja/;navigate to country Germany
+0;ALL;B;pv-profile;2012-01-01 10:00:00;2012-01-01 12:00:00;H;"[0.013, 0.018, 0.011]";None;https://www.renewables.ninja/;navigate to country Germany
+1;ALL;BB;pv-profile;2012-01-01 10:00:00;2012-01-01 12:00:00;H;"[0.015, 0.019, 0.012]";None;https://www.renewables.ninja/;navigate to country Germany


### PR DESCRIPTION
This PR clarifies the `scenario_key` for timeseries. 
* With this PR, it assumes similar values as e.g.'Base 2050' (necessary for heat demands). If a timeseries is not varied in different scenarios, `scenario_key` is 'ALL'. 
* The information about the underlying year does not have to be represented in `scenario_key`, as it is already in `timeindex_start`. The filters in the scenario specifications are adapted accordingly.
* A bug in the selection of the regions. prepare_heat_loads.py has been fixed.