### PR TITLE
Not state script as input to snakemake rules

### DIFF
--- a/Snakefile
+++ b/Snakefile
@@ -72,7 +72,6 @@ rule prepare_conv_pp:
         opsd="raw/conventional_power_plants_DE.csv",
         gpkg="raw/boundaries_germany_nuts3.gpkg",
         b3_regions="raw/b3_regions.yaml",
-        script="scripts/prepare_conv_pp.py"
     output:
         "results/_resources/scal_conv_pp.csv"
     shell:
@@ -83,42 +82,38 @@ rule prepare_feedin:
         wind_feedin="raw/time_series/ninja_wind_country_DE_current_merra-2_nuts-2_corrected.csv",
         pv_feedin="raw/time_series/ninja_pv_country_DE_merra-2_nuts-2_corrected.csv",
         ror_feedin="raw/time_series/DIW_Hydro_availability.csv",
-        script="scripts/prepare_feedin.py"
     output:
         "results/_resources/ts_feedin.csv"
     shell:
-        "python {input.script} {input.wind_feedin} {input.pv_feedin} {input.ror_feedin} {output}"
+        "python scripts/prepare_feedin.py {input.wind_feedin} {input.pv_feedin} {input.ror_feedin} {output}"
 
 rule prepare_electricity_demand:
     input:
         opsd_url=HTTP.remote("https://data.open-power-system-data.org/time_series/2020-10-06/time_series_60min_singleindex.csv",
                             keep_local=True),
-        script="scripts/prepare_electricity_demand.py"
     output:
         "results/_resources/ts_load_electricity.csv"
     shell:
-        "python {input.script} {input.opsd_url} {output}"
+        "python scripts/prepare_electricity_demand.py {input.opsd_url} {output}"
 
 rule prepare_vehicle_charging_demand:
     input:
         input_dir="raw/time_series/vehicle_charging",
-        script="scripts/prepare_vehicle_charging_demand.py"
     output:
         "results/_resources/ts_load_electricity_vehicles.csv"
     shell:
-        "python {input.script} {input.input_dir} {output}"
+        "python scripts/prepare_vehicle_charging_demand.py {input.input_dir} {output}"
 
 rule prepare_scalars:
     input:
         raw_scalars="raw/scalars_{range}_{year}.csv",
-        script="scripts/prepare_scalars.py",
     output:
         "results/_resources/scal_{range}_{year}.csv"
     wildcard_constraints:
         range=("base|high|low"),
         year=("2040|2050"),
     shell:
-        "python {input.script} {input.raw_scalars} {output}"
+        "python scripts/prepare_scalars.py {input.raw_scalars} {output}"
 
 rule prepare_heat_demand:
     input:
@@ -127,7 +122,6 @@ rule prepare_heat_demand:
         holidays="raw/holidays.csv",
         building_class="raw/building_class.csv",
         scalars="raw/scalars_base_2050.csv",
-        script="scripts/prepare_heat_demand.py",
     output:
         scalars="results/_resources/scal_load_heat.csv",
         timeseries="results/_resources/ts_load_heat.csv",
@@ -141,21 +135,19 @@ rule prepare_re_potential:
         wind="raw/area_potential/2021-05-18_wind_brandenburg_kreise_epsg32633.csv",
         kreise="raw/lookup_table_brandenburg_kreise.csv",
         assumptions="raw/scalars_base_2050.csv",
-        script="scripts/prepare_re_potential.py"
     output:
         directory("results/_resources/RE_potential/")
     shell:
-        "python {input.script} {input.pv_agriculture} {input.pv_road_railway} {input.wind} {input.kreise} {input.assumptions} {output}"
+        "python scripts/prepare_re_potential.py {input.pv_agriculture} {input.pv_road_railway} {input.wind} {input.kreise} {input.assumptions} {output}"
 
 rule process_re_potential:
     input:
         input_dir="results/_resources/RE_potential/",
-        script="scripts/process_re_potential.py"
     output:
         scalars="results/_resources/scal_power_potential_wind_pv.csv",
         table="results/_tables/potential_wind_pv_kreise.csv",
     shell:
-        "python {input.script} {input.input_dir} {output.scalars} {output.table}"
+        "python scripts/process_re_potential.py {input.input_dir} {output.scalars} {output.table}"
 
 def get_paths_scenario_input(wildcards):
     scenario_specs = load_yaml(f"scenarios/{wildcards.scenario}.yml")
@@ -218,11 +210,10 @@ rule plot_dispatch:
 rule plot_conv_pp_scalars:
     input:
         data="results/_resources/{resource}.csv",
-        script="scripts/plot_conv_pp_scalars.py"
     output:
         "results/_resources/plots/{resource}-{var_name}.png"
     shell:
-        "python {input.script} {input.data} {wildcards.var_name} {output}"
+        "python scripts/plot_conv_pp_scalars.py {input.data} {wildcards.var_name} {output}"
 
 rule plot_scalar_results:
     input:


### PR DESCRIPTION
Some of the snakemake rules state the script as input. This leads to snakemake re-running a rule if the script has changed. 

We thought that this may be useful. In my experience though it makes it harder to control the pipeline, as snakemake re-runs a lot of preprocessing rules once you switch the git branch.

This PR drops the scripts from the inputs.