### PR TITLE
Change shlp_type from ghd to gha for ghd

### DIFF
--- a/scripts/prepare_heat_demand.py
+++ b/scripts/prepare_heat_demand.py
@@ -376,7 +376,7 @@ def calculate_heat_load(carrier, holidays, temperature, yearly_demands, building
     ).get_bdew_profile()
 
     # Calculate industry, trade, service (ghd: Gewerbe, Handel, Dienstleistung)
-    # heat load using gha profile of retail and wholesale (Einzel- und Großhandel)
+    # heat load using gha profile of retail and wholesale (Einzel- und Großhandel) which has lower share of process heat
     heat_load_consumer["ghd" + "_" + carrier] = bdew.HeatBuilding(
         heat_load_consumer.index,
         holidays=holidays,

--- a/scripts/prepare_heat_demand.py
+++ b/scripts/prepare_heat_demand.py
@@ -376,12 +376,12 @@ def calculate_heat_load(carrier, holidays, temperature, yearly_demands, building
     ).get_bdew_profile()
 
     # Calculate industry, trade, service (ghd: Gewerbe, Handel, Dienstleistung)
-    # heat load
+    # heat load using gha profile of retail and wholesale (Einzel- und Großhandel)
     heat_load_consumer["ghd" + "_" + carrier] = bdew.HeatBuilding(
         heat_load_consumer.index,
         holidays=holidays,
         temperature=temperature,
-        shlp_type="ghd",
+        shlp_type="GHA",
         wind_class=0,
         annual_heat_demand=yearly_demands["ghd" + "_" + carrier][0],
         name="ghd",

--- a/scripts/prepare_heat_demand.py
+++ b/scripts/prepare_heat_demand.py
@@ -376,7 +376,8 @@ def calculate_heat_load(carrier, holidays, temperature, yearly_demands, building
     ).get_bdew_profile()
 
     # Calculate industry, trade, service (ghd: Gewerbe, Handel, Dienstleistung)
-    # heat load using gha profile of retail and wholesale (Einzel- und Großhandel) which has lower share of process heat
+    # heat load using gha profile of retail and wholesale (Einzel- und Großhandel)
+    # which has lower share of process heat
     heat_load_consumer["ghd" + "_" + carrier] = bdew.HeatBuilding(
         heat_load_consumer.index,
         holidays=holidays,


### PR DESCRIPTION
This PR changes the input parameter `shlp_type` of `bdew.HeatBuilding` function from `ghd` to `gha` in order to calculate the heat load profile of industry, trade, service (ghd: Gewerbe, Handel, Dienstleistung) with a reduced impact of medium- and high-temperature process heat.