### PR TITLE
Feature/plot scalars swap levels

### DIFF
--- a/scripts/plot_scalar_results.py
+++ b/scripts/plot_scalar_results.py
@@ -144,7 +144,10 @@ class ScalarPlot:
     def swap_levels(self, swaplevels=(0, 1)):
 
         if self.prepared_scalar_data is None:
-            raise Warning("No prepared data found")
+            logger.warning("No prepared data found")
+
+        elif not isinstance(self.prepared_scalar_data.index, pd.MultiIndex):
+            logger.warning("Index is no  pandas MultiIndex. Cannot swap levels")
 
         else:
             self.prepared_scalar_data = self.prepared_scalar_data.swaplevel(


### PR DESCRIPTION
Swaps index levels of carrier and scenario. Introduces the feature of setting the interval of the hierarchical label depending on the length of the labels.

TODO:
* [x] Fix single scenario plots: Nothing to swap here.