### PR TITLE
Keep scenario order in scalar plots

### DIFF
--- a/scripts/plot_scalar_results.py
+++ b/scripts/plot_scalar_results.py
@@ -735,10 +735,13 @@ if __name__ == "__main__":
         plot.prepared_scalar_data = plot.prepared_scalar_data.filter(
             items=["var_value"]
         )
+
+        # Remember index to apply it after unstacking
         index = plot.prepared_scalar_data.index.get_level_values(0).unique()
         # Unstack prepared and filtered data regarding carriers
         plot.prepared_scalar_data = plot.prepared_scalar_data.unstack("var_name")
 
+        # Reindex to keep previous scenario order
         plot.prepared_scalar_data = plot.prepared_scalar_data.reindex(index)
 
         # Get names of data's columns

--- a/scripts/plot_scalar_results.py
+++ b/scripts/plot_scalar_results.py
@@ -735,8 +735,11 @@ if __name__ == "__main__":
         plot.prepared_scalar_data = plot.prepared_scalar_data.filter(
             items=["var_value"]
         )
+        index = plot.prepared_scalar_data.index.get_level_values(0).unique()
         # Unstack prepared and filtered data regarding carriers
         plot.prepared_scalar_data = plot.prepared_scalar_data.unstack("var_name")
+
+        plot.prepared_scalar_data = plot.prepared_scalar_data.reindex(index)
 
         # Get names of data's columns
         column_names = plot.prepared_scalar_data.columns


### PR DESCRIPTION
The order had changed in demand_stacked_carriers_electricity_heat_central_heat_decentral_h2_ch4.png and in flow_out_electricity_heat_central_heat_decentral_h2_ch4_subplots.png.