### PR TITLE
Scenario labels can be set for joined plots

### DIFF
--- a/scenarios/2050-el_eff.yml
+++ b/scenarios/2050-el_eff.yml
@@ -4,6 +4,7 @@
 # build_datapackage
 
 name: 2050-el_eff
+label: Efficiency-Scenario
 
 datetimeindex:
   start:

--- a/scripts/plot_scalar_results.py
+++ b/scripts/plot_scalar_results.py
@@ -28,6 +28,7 @@ import numpy as np
 import oemoflex.tools.plots as plots
 import pandas as pd
 from oemoflex.tools.plots import plot_grouped_bar
+from oemoflex.tools.helpers import load_yaml
 
 from oemof_b3 import colors_odict, labels_dict
 from oemof_b3.config import config
@@ -70,6 +71,20 @@ def draw_standalone_legend(c_dict):
     )
     plt.tight_layout()
     return fig
+
+
+def set_scenario_labels(df):
+    """Replaces scenario name with scenario label if possible"""
+
+    def get_scenario_label(scenario):
+        try:
+            scenario_settings = load_yaml(f"scenarios/{scenario}.yml")
+        except FileNotFoundError:
+            return scenario
+        return scenario_settings.get("label", scenario)
+
+    df.index = df.index.map(get_scenario_label)
+    return df
 
 
 def prepare_scalar_data(df, colors_odict, labels_dict, conv_number, tolerance=1e-3):
@@ -410,6 +425,7 @@ if __name__ == "__main__":
 
     # Load scalar data
     scalars = load_scalars(scalars_path)
+    scalars = set_scenario_labels(scalars)
 
     # To obey flake8
     colors_odict = colors_odict


### PR DESCRIPTION
`plot_scalar_results` looks for key `label` in related scenario yaml and replaces plot label, if it can find one.
If it fails to find a label, original scenario name is taken. 
Added label to scenario _2050-el_eff_ for testing purposes.
Tested with `snakemake -j1 results/joined_scenarios/all-optimized/joined_plotted`