### PR TITLE
Adapt and add info on constraints in docs and docstrings

### DIFF
--- a/docs/model_structure.rst
+++ b/docs/model_structure.rst
@@ -25,8 +25,10 @@ that format already.
 oemof-B3 resources
 ------------------
 
-The resources are preprocessed data that serves as material for building scenarios. They follow
-a common data schema defined in :file:`oemof_b3/schema/` and are located in :file:`oemof_b3/raw/scalars` and :file:`oemof_b3/raw/time_series`.
+The resources are preprocessed data that serves as material for building scenarios.
+Because they are a first intermediate result, resources will be saved in :file:`results/_resources`.
+The resources follow a common data schema defined in :file:`oemof_b3/schema/`.
+There is a separate schema for scalars and for timeseries:
 
 Scalars
 
@@ -40,7 +42,7 @@ Time series
    :delim: ;
    :file: ../oemof_b3/schema/timeseries.csv
 
-Within oemof-B3, resources are located in :file:`results/_resources`.
+
 A few more conventions are important to know. Missing data is left empty. If a value applies to all
 regions, this is indicated by :attr:`ALL`. If it applies to the sum of regions, by :attr:`TOTAL`.
 There is no unit transformation within the model, i.e. the user needs to ensure the consistency of units.

--- a/docs/model_structure.rst
+++ b/docs/model_structure.rst
@@ -23,7 +23,7 @@ oemof-B3 resources
 ------------------
 
 The resources are preprocessed data that serves as material for building scenarios. They follow
-a common data schema defined in :file:`oemof_b3/schema/`.
+a common data schema defined in :file:`oemof_b3/schema/` and are located in :file:`oemof_b3/raw/scalars` and :file:`oemof_b3/raw/time_series`.
 
 Scalars
 

--- a/docs/model_structure.rst
+++ b/docs/model_structure.rst
@@ -17,9 +17,10 @@ The busses used in addition to the electricity bus in oemof-B3 are given in :fil
 Raw data
 --------
 
-Raw data from external source comes in different formats. As a first step, preprocessing scripts in
-the model pipeline (see :ref:`Preprocessing`) convert it into the oemof-B3-resources-format,
-explained in the next section. Raw data that represents model-own assumptions is provided in that format already.
+Raw data from external source comes in different formats. It is provided in :file:`raw/`.
+As a first step, preprocessing scripts in the model pipeline (see :ref:`Preprocessing`) convert it into the
+oemof-B3-resources-format, explained in the next section. Raw data that represents model-own assumptions is provided in
+that format already.
 
 oemof-B3 resources
 ------------------

--- a/docs/model_structure.rst
+++ b/docs/model_structure.rst
@@ -41,6 +41,12 @@ A few more conventions are important to know. Missing data is left empty. If a v
 regions, this is indicated by :attr:`ALL`. If it applies to the sum of regions, by :attr:`TOTAL`.
 There is no unit transformation within the model, i.e. the user needs to ensure the consistency of units.
 
+Further information about specific parameters should be known.
+Components can receive keywords for the electricity gas relation constraint in variable `output_parameters`.
+Keywords of components powered by gas start with `config.settings.optimize.gas_key` and such powered
+with electricity with `config.settings.optimize.el_key` followed by `carrier` and `region` (example: `{"electricity-heat_decentral-B": 1}`).
+Do not provide `output_parameters` or leave their `var_value` empty to neglect a component in the constraint.
+
 Preprocessed datapackages
 -------------------------
 

--- a/docs/model_structure.rst
+++ b/docs/model_structure.rst
@@ -10,7 +10,9 @@ Model structure
     :backlinks: top
 
 In oemof-B3, data appears in different formats in each processing step. Here, we give a short
-overview.
+overview. In general, it should be noted that energy carriers are not the same as busses.
+For example, electricity can be generated from the energy carrier biomass without biomass being added as a bus.
+The busses used in addition to the electricity bus in oemof-B3 are given in :file:`bus_attrs_update.yml`.
 
 Raw data
 --------

--- a/docs/model_structure.rst
+++ b/docs/model_structure.rst
@@ -48,7 +48,9 @@ The resources are then again preprocessed together with the scenario information
 scenario-specific datapackages. A preprocessed datapackage represents an instance of an energy system scenario.
 It is a collection of .csv-files, one file for all busses and one for each
 component, stored in :file:`elements` (scalars data) and :file:`sequences` (time series for e.g.
-renewable feedin or demand profiles), stored in separate folders. Below is an example of the element
+renewable feedin or demand profiles), stored in separate folders.
+A separate file, :file:`additional_scalars.csv`, contains information on constraints but will be integrated into the datapackage in the future.
+Below is an example of the element
 file for the gas turbine of the base examples scenario, which can be found in
 :file:`examples/base/preprocessed/base/data/elements/ch4-gt.csv`.
 

--- a/docs/model_structure.rst
+++ b/docs/model_structure.rst
@@ -42,10 +42,10 @@ regions, this is indicated by :attr:`ALL`. If it applies to the sum of regions, 
 There is no unit transformation within the model, i.e. the user needs to ensure the consistency of units.
 
 Further information about specific parameters should be known.
-Components can receive keywords for the electricity gas relation constraint in variable `output_parameters`.
-Keywords of components powered by gas start with `config.settings.optimize.gas_key` and such powered
-with electricity with `config.settings.optimize.el_key` followed by `carrier` and `region` (example: `{"electricity-heat_decentral-B": 1}`).
-Do not provide `output_parameters` or leave their `var_value` empty to neglect a component in the constraint.
+Components can receive keywords for the electricity gas relation constraint in variable :attr:`output_parameters`.
+Keywords of components powered by gas start with :attr:`config.settings.optimize.gas_key` and such powered
+with electricity with :attr:`config.settings.optimize.el_key` followed by :attr:`carrier` and :attr:`region` (example: :attr:`{"electricity-heat_decentral-B": 1}`).
+Do not provide :attr:`output_parameters` or leave their :attr:`var_value` empty to neglect a component in the constraint.
 
 Preprocessed datapackages
 -------------------------

--- a/docs/model_structure.rst
+++ b/docs/model_structure.rst
@@ -78,6 +78,8 @@ More generally, there are specific variables which depend on the type of the com
 their properties are defined in
 `oemoflex <https://github.com/rl-institut/oemoflex/tree/dev/oemoflex/model>`_.
 Components and properties can also be added or updated in oemof-B3 using the files in :file:`oemof_b3/model/`.
+You can have a look at the structure of a datapackage using our example:
+`datapackage of "example_base" <https://github.com/rl-institut/oemof-B3/tree/dev/examples/example_base/preprocessed>`_.
 
 .. todo: Explain how to do this and when it is relevant.
 

--- a/docs/model_structure.rst
+++ b/docs/model_structure.rst
@@ -40,6 +40,7 @@ Time series
    :delim: ;
    :file: ../oemof_b3/schema/timeseries.csv
 
+Within oemof-B3 resources are located in :file:`results/_resources`.
 A few more conventions are important to know. Missing data is left empty. If a value applies to all
 regions, this is indicated by :attr:`ALL`. If it applies to the sum of regions, by :attr:`TOTAL`.
 There is no unit transformation within the model, i.e. the user needs to ensure the consistency of units.

--- a/docs/model_structure.rst
+++ b/docs/model_structure.rst
@@ -25,7 +25,7 @@ that format already.
 oemof-B3 resources
 ------------------
 
-The resources are preprocessed data that serves as material for building scenarios.
+The resources are preprocessed data that serve as material for building scenarios.
 Because they are a first intermediate result, resources will be saved in :file:`results/_resources`.
 The resources follow a common data schema defined in :file:`oemof_b3/schema/`.
 There is a separate schema for scalars and for timeseries:
@@ -56,34 +56,33 @@ Do not provide :attr:`output_parameters` or leave their :attr:`var_value` empty 
 Preprocessed datapackages
 -------------------------
 
-The resources are then again preprocessed together with the scenario information to generate
-scenario-specific datapackages. A preprocessed datapackage represents an instance of an energy system scenario.
-It is a collection of .csv-files, one file for all busses and one for each
+The next intermediate step is a preprocessed datapackage, which is built using resources,
+scenario information and the information about the model structure.
+A preprocessed datapackage represents an instance of an :class:`oemof.solph.EnergySystem`.
+
+A datapackage is a collection of data in form of csv-files and metadata in form of a json.
+The data consists one file for all busses and one for each
 component, stored in :file:`results/<scenario>/preprocessed/data/elements` (scalar data) and
 :file:`results/<scenario>/preprocessed/data/sequences` (time series for e.g. renewable feed-in or demand profiles),
 stored in separate folders.
-A separate file, :file:`additional_scalars.csv`, contains information on constraints but will be integrated into the
-datapackage in the future.
+
+The examples in oemof-B3 are readily preprocessed datapackages (e.g. `<https://github.com/rl-institut/oemof-B3/tree/dev/examples/example_base/preprocessed>`_).
 Below is an example of the element file for the gas turbine of the base examples scenario, which can be found in
 :file:`examples/base/preprocessed/base/data/elements/ch4-gt.csv`.
 
-.. todo: Explain more about scenarios, where and how they are defined and thus how new ones can be made
+.. csv-table::
+   :delim: ,
+   :file: ../examples/example_base/preprocessed/data/elements/ch4-gt.csv
 
-=======  =========  ==========  =======  =====  ========  ==============  ========  =============  ===========  =============  =============  ==========  =================
-region   name       type        carrier  tech   from_bus  to_bus          capacity  capacity_cost  efficiency   carrier_cost   marginal_cost  expandable  output_paramters
-=======  =========  ==========  =======  =====  ========  ==============  ========  =============  ===========  =============  =============  ==========  =================
-BE       BE-ch4-gt  conversion  ch4      gt     BE-ch4    BE-electricity  1500000                  0.619        0.021          0.0045         False       {}
-BB       BB-ch4-gt  conversion  ch4      gt     BB-ch4    BB-electricity  600000                   0.619        0.021          0.0045         False       {}
-=======  =========  ==========  =======  =====  ========  ==============  ========  =============  ===========  =============  =============  ==========  =================
+A separate file, :file:`additional_scalars.csv`, can contain additional information on constraints.
+This file is not described in the metadata yet, but will become an official part of the datapackage in the future.
 
-More generally, there are specific variables which depend on the type of the component. Components and
-their attributes are defined in
+Other than the examples, the datapackages representing actual scenarios are built automatically from the resources,
+the scenario informationscenario/<scenario.yml> and the `model structure <https://github.com/rl-institut/oemof-B3/tree/dev/oemof_b3/model/model_structure>`_.
+
+Components and their attributes are defined in
 `oemoflex <https://github.com/rl-institut/oemoflex/tree/dev/oemoflex/model/component_attrs.yml>`_.
 Components and properties can also be added or updated in oemof-B3 using the files in :file:`oemof_b3/model/`.
-You can have a look at the structure of a datapackage using our example:
-`datapackage of "example_base" <https://github.com/rl-institut/oemof-B3/tree/dev/examples/example_base/preprocessed>`_.
-
-.. todo: Explain how to do this and when it is relevant.
 
 Postprocessed data
 -------------------

--- a/docs/model_structure.rst
+++ b/docs/model_structure.rst
@@ -57,11 +57,12 @@ Preprocessed datapackages
 The resources are then again preprocessed together with the scenario information to generate
 scenario-specific datapackages. A preprocessed datapackage represents an instance of an energy system scenario.
 It is a collection of .csv-files, one file for all busses and one for each
-component, stored in :file:`elements` (scalars data) and :file:`sequences` (time series for e.g.
-renewable feedin or demand profiles), stored in separate folders.
-A separate file, :file:`additional_scalars.csv`, contains information on constraints but will be integrated into the datapackage in the future.
-Below is an example of the element
-file for the gas turbine of the base examples scenario, which can be found in
+component, stored in :file:`results/<scneario_key>/preprocessed/data/elements` (scalars data) and
+:file:`results/<scneario_key>/preprocessed/data/sequences` (time series for e.g. renewable feedin or demand profiles),
+stored in separate folders.
+A separate file, :file:`additional_scalars.csv`, contains information on constraints but will be integrated into the
+datapackage in the future.
+Below is an example of the element file for the gas turbine of the base examples scenario, which can be found in
 :file:`examples/base/preprocessed/base/data/elements/ch4-gt.csv`.
 
 .. todo: Explain more about scenarios, where and how they are defined and thus how new ones can be made

--- a/docs/model_structure.rst
+++ b/docs/model_structure.rst
@@ -10,9 +10,7 @@ Model structure
     :backlinks: top
 
 In oemof-B3, data appears in different formats in each processing step. Here, we give a short
-overview. In general, it should be noted that energy carriers are not the same as busses.
-For example, electricity can be generated from the energy carrier biomass without biomass being added as a bus.
-The busses used in addition to the electricity bus in oemof-B3 are given in :file:`bus_attrs_update.yml`.
+overview.
 
 Raw data
 --------
@@ -21,6 +19,12 @@ Raw data from external source comes in different formats. It is not part of the 
 As a first step, preprocessing scripts in the model pipeline (see :ref:`Preprocessing`) convert it into the
 oemof-B3-resources-format, explained in the next section. Raw data that represents model-own assumptions is provided in
 that format already.
+
+The following additional information about specific parameters should be considered:
+Components can receive keywords for the electricity-gas-relation-constraint via the attribute :attr:`output_parameters`.
+Keywords of components powered by gas start with :attr:`config.settings.optimize.gas_key` and such powered
+with electricity with :attr:`config.settings.optimize.el_key` followed by :attr:`carrier` and :attr:`region` (example: :attr:`{"electricity-heat_decentral-B": 1}`).
+Do not provide :attr:`output_parameters` or leave their :attr:`var_value` empty to neglect a component in the constraint.
 
 oemof-B3 resources
 ------------------
@@ -46,12 +50,6 @@ Time series
 A few more conventions are important to know. Missing data is left empty. If a value applies to all
 regions, this is indicated by :attr:`ALL`. If it applies to the sum of regions, by :attr:`TOTAL`.
 There is no unit transformation within the model, i.e. the user needs to ensure the consistency of units.
-
-The following additional information about specific parameters should be considered:
-Components can receive keywords for the electricity-gas-relation-constraint via the attribute :attr:`output_parameters`.
-Keywords of components powered by gas start with :attr:`config.settings.optimize.gas_key` and such powered
-with electricity with :attr:`config.settings.optimize.el_key` followed by :attr:`carrier` and :attr:`region` (example: :attr:`{"electricity-heat_decentral-B": 1}`).
-Do not provide :attr:`output_parameters` or leave their :attr:`var_value` empty to neglect a component in the constraint.
 
 Preprocessed datapackages
 -------------------------

--- a/docs/model_structure.rst
+++ b/docs/model_structure.rst
@@ -17,7 +17,7 @@ The busses used in addition to the electricity bus in oemof-B3 are given in :fil
 Raw data
 --------
 
-Raw data from external source comes in different formats. It is provided in :file:`raw/`.
+Raw data from external source comes in different formats. It is not part of the model on GitHub, but has to be downloaded separately and provided in the directory :file:`raw/`.
 As a first step, preprocessing scripts in the model pipeline (see :ref:`Preprocessing`) convert it into the
 oemof-B3-resources-format, explained in the next section. Raw data that represents model-own assumptions is provided in
 that format already.
@@ -40,13 +40,13 @@ Time series
    :delim: ;
    :file: ../oemof_b3/schema/timeseries.csv
 
-Within oemof-B3 resources are located in :file:`results/_resources`.
+Within oemof-B3, resources are located in :file:`results/_resources`.
 A few more conventions are important to know. Missing data is left empty. If a value applies to all
 regions, this is indicated by :attr:`ALL`. If it applies to the sum of regions, by :attr:`TOTAL`.
 There is no unit transformation within the model, i.e. the user needs to ensure the consistency of units.
 
-Further information about specific parameters should be known.
-Components can receive keywords for the electricity gas relation constraint in variable :attr:`output_parameters`.
+The following additional information about specific parameters should be considered:
+Components can receive keywords for the electricity-gas-relation-constraint via the attribute :attr:`output_parameters`.
 Keywords of components powered by gas start with :attr:`config.settings.optimize.gas_key` and such powered
 with electricity with :attr:`config.settings.optimize.el_key` followed by :attr:`carrier` and :attr:`region` (example: :attr:`{"electricity-heat_decentral-B": 1}`).
 Do not provide :attr:`output_parameters` or leave their :attr:`var_value` empty to neglect a component in the constraint.
@@ -57,8 +57,8 @@ Preprocessed datapackages
 The resources are then again preprocessed together with the scenario information to generate
 scenario-specific datapackages. A preprocessed datapackage represents an instance of an energy system scenario.
 It is a collection of .csv-files, one file for all busses and one for each
-component, stored in :file:`results/<scneario_key>/preprocessed/data/elements` (scalars data) and
-:file:`results/<scneario_key>/preprocessed/data/sequences` (time series for e.g. renewable feedin or demand profiles),
+component, stored in :file:`results/<scenario>/preprocessed/data/elements` (scalar data) and
+:file:`results/<scenario>/preprocessed/data/sequences` (time series for e.g. renewable feed-in or demand profiles),
 stored in separate folders.
 A separate file, :file:`additional_scalars.csv`, contains information on constraints but will be integrated into the
 datapackage in the future.
@@ -75,8 +75,8 @@ BB       BB-ch4-gt  conversion  ch4      gt     BB-ch4    BB-electricity  600000
 =======  =========  ==========  =======  =====  ========  ==============  ========  =============  ===========  =============  =============  ==========  =================
 
 More generally, there are specific variables which depend on the type of the component. Components and
-their properties are defined in
-`oemoflex <https://github.com/rl-institut/oemoflex/tree/dev/oemoflex/model>`_.
+their attributes are defined in
+`oemoflex <https://github.com/rl-institut/oemoflex/tree/dev/oemoflex/model/component_attrs.yml>`_.
 Components and properties can also be added or updated in oemof-B3 using the files in :file:`oemof_b3/model/`.
 You can have a look at the structure of a datapackage using our example:
 `datapackage of "example_base" <https://github.com/rl-institut/oemof-B3/tree/dev/examples/example_base/preprocessed>`_.

--- a/docs/model_structure.rst
+++ b/docs/model_structure.rst
@@ -64,7 +64,7 @@ BB       BB-ch4-gt  conversion  ch4      gt     BB-ch4    BB-electricity  600000
 More generally, there are specific variables which depend on the type of the component. Components and
 their properties are defined in
 `oemoflex <https://github.com/rl-institut/oemoflex/tree/dev/oemoflex/model>`_.
-Components and properties and also be added or updated in oemof-B3 using the files in :file:`oemof_b3/model/`.
+Components and properties can also be added or updated in oemof-B3 using the files in :file:`oemof_b3/model/`.
 
 .. todo: Explain how to do this and when it is relevant.
 

--- a/scripts/optimize.py
+++ b/scripts/optimize.py
@@ -156,13 +156,10 @@ def add_electricity_gas_relation_constraints(model, relations):
     r"""
     Adds constraint `equate_flows_by_keyword` to `model`.
 
-    The components belonging to one constraint are selected by keywords. The keywords of components
-    powered by gas start with `config.settings.optimize.gas_key` and such powered with
+    The components belonging to 'electricity' or 'gas' are selected by keywords. The keywords of
+    components powered by gas start with `config.settings.optimize.gas_key` and such powered by
     electricity with `config.settings.optimize.el_key`, followed by `carrier` and `region` e.g.
     <`GAS_KEY`>-<carrier>-<region>.
-    Attention: Although a value is provided for the keywords in the input data
-    (e.g. {"electricity-heat_central-B": 1}) this value does not have any effect, at the moment.
-    If a component is not to be taken into account the keyword must not be provided.
 
     Parameters
     ----------

--- a/scripts/optimize.py
+++ b/scripts/optimize.py
@@ -157,8 +157,9 @@ def add_electricity_gas_relation_constraints(model, relations):
     Adds constraint `equate_flows_by_keyword` to `model`.
 
     The components belonging to one constraint are selected by keywords. The keywords of components
-    powered by any gas start with `GAS_KEY` and such powered with electricity with `EL_KEY`,
-    respectively: <`GAS_KEY`>-<carrier>-<region>.
+    powered by gas start with `config.settings.optimize.gas_key` and such powered with
+    electricity with `config.settings.optimize.el_key`, followed by `carrier` and `region` e.g.
+    <`GAS_KEY`>-<carrier>-<region>.
     Attention: Although a value is provided for the keywords in the input data
     (e.g. {"electricity-heat_central-B": 1}) this value does not have any effect, at the moment.
     If a component is not to be taken into account the keyword must not be provided.


### PR DESCRIPTION
Fix #191

Changes in this PR:

- added information on `additional_scalars.csv` to docs in the section of [preprocessed datapackages](https://oemof-b3.readthedocs.io/en/latest/model_structure.html#preprocessed-datapackages)
- added information on keywords of electricity gas relation constraint to docs in the section of [oemof-B3 resources](https://oemof-b3.readthedocs.io/en/latest/model_structure.html#oemof-b3-resources)
- added directory of oemof-b3 resources to docs
- minor correction in docs
- generalize gas and electricity key in docstring of `add_electricity_gas_relation_constraints()`