### PR TITLE
Remove Windows issue from docs

### DIFF
--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -7,7 +7,7 @@ Examples
 To give a quick intro into oemof-B3's capabilities, we provide 3 simple
 `examples <https://github.com/rl-institut/oemof-B3/tree/dev/examples>`_.
 
-To run all example scenarios, execute on a linux system:
+To run all example scenarios, execute:
 
 ::
 

--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -140,26 +140,6 @@ Alternatively, to create just the output file or directory of one rule, run:
      snakemake -j<NUMBER_OF_CPU_CORES> <output file or folder>
 
 
-Snakemake on Windows
-^^^^^^^^^^^^^^^^^^^^
-
-When running snakemake with output files in subfolders on Windows with
-
-::
-
-     snakemake -j<NUMBER_OF_CPU_CORES>
-
-a ``MissingRuleException`` is raised. The process is unable to specify the output files in subfolders.
-This bug is an `open issue <https://github.com/snakemake/snakemake/issues/46>`_
-in snakemake.
-A current workaround is described in `pypsa-eur <https://pypsa-eur.readthedocs.io/en/latest/tutorial.html?highlight=windows#how-to-use-the-snakemake-rules>`_.
-is to run snakemake with the flag ``--keep-target-files`` to the command.
-
-::
-
-     snakemake -j<NUMBER_OF_CPU_CORES> --keep-target-files
-
-
 Contributing to oemof-B3
 ========================
 


### PR DESCRIPTION
There has been an issue in Windows with snakemake (https://github.com/snakemake/snakemake/issues/46), but that issue is closed now. I have tested snakemake execution in Windows with several rules and it worked without error. Also pypsa-eur, which we cited as a source for the workaround, doesn't mention the issue anymore (https://pypsa-eur.readthedocs.io/en/latest/tutorial.html?highlight=windows#how-to-use-the-snakemake-rules). This PR therefore abolishes the explanation of the issue and the workaround in the docs. (corresponding issue: #318)