### PR TITLE
Features/add empty ts

### DIFF
--- a/Snakefile
+++ b/Snakefile
@@ -94,6 +94,7 @@ include: "snakemake_rules/postprocessing.smk"
 include: "snakemake_rules/visualization.smk"
 include: "snakemake_rules/oep_upload.smk"
 include: "snakemake_rules/create_empty_scalars.smk"
+include: "snakemake_rules/create_empty_ts.smk"
 
 # prepare settings locally or download it from OEP (not implemented yet)
 if config.settings.general.prepare_resources_locally:

--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -143,13 +143,7 @@ Alternatively, to create just the output file or directory of one rule, run:
 Contributing to oemof-B3
 ========================
 
-Executing the rule
-
-::
-
-    snakemake -j1 create_empty_scalars
-
-will create empty scalars. The rule
+The rule
 
 ::
 

--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -143,5 +143,21 @@ Alternatively, to create just the output file or directory of one rule, run:
 Contributing to oemof-B3
 ========================
 
+Executing the rule
+
+::
+
+    snakemake -j1 create_empty_scalars
+
+will create empty scalars. The rule
+
+::
+
+    snakemake -j1 create_empty_ts
+
+will create empty time series data.
+The empty scalars and time series data can be used to verify your energy system model in the preprocessing stage.
+
+
 You can write `issues <https://github.com/rl-institut/oemof-B3/issues>`_ to announce bugs or
 to propose enhancements.

--- a/docs/prepare_resources/create_empty_ts.rst
+++ b/docs/prepare_resources/create_empty_ts.rst
@@ -1,0 +1,7 @@
+.. _create_empty_ts_label:
+
+create_empty_ts
+===============
+
+.. automodule:: create_empty_ts
+   :members:

--- a/oemof_b3/config/settings.yaml
+++ b/oemof_b3/config/settings.yaml
@@ -109,6 +109,7 @@ create_empty_ts:
   {
       "datetime_format": "%Y-%m-%d %H:%M:%S",
       "filter_ts": "empty_ts",
-      "ts_values": "zeros"  # Set to 'zeros' or 'empty'
+      "ts_values": "zeros",  # Set to 'zeros' or 'empty'
+      "overwrite": false
   }
 

--- a/oemof_b3/config/settings.yaml
+++ b/oemof_b3/config/settings.yaml
@@ -107,7 +107,7 @@ create_empty_scalars:
 
 create_empty_ts:
   {
-      "datetime_format": "%Y-%m-%d",
+      "datetime_format": "%Y-%m-%d %H:%M:%S",
       "filter_ts": "empty_ts",
       "ts_values": "zeros"  # Set to 'zeros' or 'empty'
   }

--- a/oemof_b3/config/settings.yaml
+++ b/oemof_b3/config/settings.yaml
@@ -104,3 +104,11 @@ create_empty_scalars:
       "var_unit": "None",
   }
   drop_default_scalars: True
+
+create_empty_ts:
+  {
+      "datetime_format": "%Y-%m-%d",
+      "filter_ts": "empty_ts",
+      "ts_values": "zeros"  # Set to 'zeros' or 'empty'
+  }
+

--- a/oemof_b3/config/settings.yaml
+++ b/oemof_b3/config/settings.yaml
@@ -106,10 +106,9 @@ create_empty_scalars:
   drop_default_scalars: True
 
 create_empty_ts:
-  {
-      "datetime_format": "%Y-%m-%d %H:%M:%S",
-      "filter_ts": "empty_ts",
-      "ts_values": "zeros",  # Set to 'zeros' or 'empty'
-      "overwrite": false
-  }
+  datetime_format: "%Y-%m-%d %H:%M:%S"
+  filter_ts: "empty_ts"
+  ts_values: "zeros"  # Set to 'zeros' or 'empty'
+  overwrite: false
+
 

--- a/scripts/create_empty_ts.py
+++ b/scripts/create_empty_ts.py
@@ -35,7 +35,6 @@ from oemof_b3 import model
 from oemof_b3.tools.data_processing import (
     HEADER_B3_TS,
     stack_timeseries,
-    load_b3_timeseries,
 )
 
 
@@ -204,10 +203,10 @@ def drop_duplicates(_df):
 
     Notes
     -----
-    Duplicate rows are determined based on the values in the specified columns. By default, all columns
-    except the "series" column are used to determine duplicates. If there are multiple rows with the same
-    values in the specified columns, only the first occurrence is kept and subsequent occurrences are
-    dropped.
+    Duplicate rows are determined based on the values in the specified columns. By default, all
+    columns except the "series" column are used to determine duplicates. If there are multiple rows
+    with the same values in the specified columns, only the first occurrence is kept and subsequent
+    occurrences are dropped.
     """
     columns = [col for col in _df.columns if col != "series"]
 

--- a/scripts/create_empty_ts.py
+++ b/scripts/create_empty_ts.py
@@ -32,7 +32,11 @@ from datetime import datetime
 from oemof_b3.config.config import load_yaml, settings
 from oemof_b3.model import model_structures
 from oemof_b3 import model
-from oemof_b3.tools.data_processing import HEADER_B3_TS, stack_timeseries, load_b3_timeseries
+from oemof_b3.tools.data_processing import (
+    HEADER_B3_TS,
+    stack_timeseries,
+    load_b3_timeseries,
+)
 
 
 def get_sub_dict(subsub_key, _dict):
@@ -126,7 +130,9 @@ def create_empty_ts(name):
     datetime_format = settings.create_empty_ts.datetime_format
 
     # Get start date from scenario specifications
-    start = datetime.strptime(scenario_specs["filter_timeseries"]["timeindex_start"], datetime_format)
+    start = datetime.strptime(
+        scenario_specs["filter_timeseries"]["timeindex_start"], datetime_format
+    )
 
     # Get periods and freq from scenario specifications
     periods = scenario_specs["datetimeindex"]["periods"]
@@ -184,24 +190,24 @@ def get_df_of_all_empty_ts(profile_names, _region):
 
 def drop_duplicates(_df):
     """
-        Remove duplicate rows from a pandas DataFrame based on specified columns.
+    Remove duplicate rows from a pandas DataFrame based on specified columns.
 
-        Parameters
-        ----------
-        _df : pandas DataFrame
-            The DataFrame to remove duplicates from.
+    Parameters
+    ----------
+    _df : pandas DataFrame
+        The DataFrame to remove duplicates from.
 
-        Returns
-        -------
-        _df : pandas DataFrame
-            The updated DataFrame with duplicate rows removed.
+    Returns
+    -------
+    _df : pandas DataFrame
+        The updated DataFrame with duplicate rows removed.
 
-        Notes
-        -----
-        Duplicate rows are determined based on the values in the specified columns. By default, all columns
-        except the "series" column are used to determine duplicates. If there are multiple rows with the same
-        values in the specified columns, only the first occurrence is kept and subsequent occurrences are
-        dropped.
+    Notes
+    -----
+    Duplicate rows are determined based on the values in the specified columns. By default, all columns
+    except the "series" column are used to determine duplicates. If there are multiple rows with the same
+    values in the specified columns, only the first occurrence is kept and subsequent occurrences are
+    dropped.
     """
     columns = [col for col in _df.columns if col != "series"]
 
@@ -300,12 +306,18 @@ if __name__ == "__main__":
 
             if efficiency_names:
                 df_efficiencies = get_df_of_all_empty_ts(efficiency_names, region)
-                all_efficiencies_ts = pd.concat([all_efficiencies_ts, df_efficiencies], ignore_index=True)
+                all_efficiencies_ts = pd.concat(
+                    [all_efficiencies_ts, df_efficiencies], ignore_index=True
+                )
 
     ts_dict = {
         "load": (load_names, all_load_ts, path_empty_load_ts),
         "feedin": (feedin_names, all_feedin_ts, path_empty_ts_feedin),
-        "efficiency": (efficiency_names, all_efficiencies_ts, path_empty_ts_efficiencies),
+        "efficiency": (
+            efficiency_names,
+            all_efficiencies_ts,
+            path_empty_ts_efficiencies,
+        ),
     }
 
     for ts_type, (ts_name, ts_df, ts_path) in ts_dict.items():

--- a/scripts/create_empty_ts.py
+++ b/scripts/create_empty_ts.py
@@ -231,12 +231,12 @@ if __name__ == "__main__":
         load_names = [
             attr_subdict["profile"]
             for attr_subdict in foreign_keys_profile
-            if "demand" in attr_subdict["profile"]
+            if "demand" in attr_subdict["profile"]  # noqa: E713
         ]
         feedin_names = [
             attr_subdict["profile"]
             for attr_subdict in foreign_keys_profile
-            if not "demand" in attr_subdict["profile"]
+            if not "demand" in attr_subdict["profile"]  # noqa: E713
         ]
         efficiency_names = [
             attr_subdict["efficiency"] for attr_subdict in foreign_keys_efficiency

--- a/scripts/create_empty_ts.py
+++ b/scripts/create_empty_ts.py
@@ -32,7 +32,7 @@ from datetime import datetime
 from oemof_b3.config.config import load_yaml, settings
 from oemof_b3.model import model_structures
 from oemof_b3 import model
-from oemof_b3.tools.data_processing import HEADER_B3_TS, stack_timeseries
+from oemof_b3.tools.data_processing import HEADER_B3_TS, stack_timeseries, load_b3_timeseries
 
 
 def get_sub_dict(subsub_key, _dict):
@@ -182,6 +182,37 @@ def get_df_of_all_empty_ts(profile_names, _region):
     return ts_df
 
 
+def drop_duplicates(_df):
+    """
+        Remove duplicate rows from a pandas DataFrame based on specified columns.
+
+        Parameters
+        ----------
+        _df : pandas DataFrame
+            The DataFrame to remove duplicates from.
+
+        Returns
+        -------
+        _df : pandas DataFrame
+            The updated DataFrame with duplicate rows removed.
+
+        Notes
+        -----
+        Duplicate rows are determined based on the values in the specified columns. By default, all columns
+        except the "series" column are used to determine duplicates. If there are multiple rows with the same
+        values in the specified columns, only the first occurrence is kept and subsequent occurrences are
+        dropped.
+    """
+    columns = [col for col in _df.columns if col != "series"]
+
+    _df = _df.drop_duplicates(
+        subset=columns,
+        ignore_index=True,
+    )
+
+    return _df
+
+
 def save_ts(_df, path):
     """
     This function saves time series that contain values of datetime format
@@ -197,12 +228,16 @@ def save_ts(_df, path):
 
 
     """
-    _df.to_csv(
-        path,
-        index=True,
-        date_format="%Y-%m-%d %H:%M:%S",
-        sep=settings.general.separator,
-    )
+    if not os.path.exists(path):
+
+        _df.index.name = "id_ts"
+
+        _df.to_csv(
+            path,
+            index=True,
+            date_format="%Y-%m-%d %H:%M:%S",
+            sep=settings.general.separator,
+        )
 
 
 if __name__ == "__main__":
@@ -213,6 +248,10 @@ if __name__ == "__main__":
     path_empty_ts_efficiencies = sys.argv[4]
 
     scenarios = os.listdir(scenarios_dir)
+
+    all_load_ts = pd.DataFrame(columns=HEADER_B3_TS)
+    all_feedin_ts = pd.DataFrame(columns=HEADER_B3_TS)
+    all_efficiencies_ts = pd.DataFrame(columns=HEADER_B3_TS)
 
     for scenario_specs in scenarios:
         scenario_specs = load_yaml(os.path.join(scenarios_dir, scenario_specs))
@@ -243,15 +282,33 @@ if __name__ == "__main__":
             attr_subdict["efficiency"] for attr_subdict in foreign_keys_efficiency
         ]
 
+        ts_dict = {
+            "load": load_names,
+            "feedin": feedin_names,
+            "efficiency": efficiency_names,
+        }
+
         for region in model_structure["regions"]:
+
             if load_names:
                 df_loads = get_df_of_all_empty_ts(load_names, region)
-                save_ts(df_loads, path_empty_load_ts)
+                all_load_ts = pd.concat([all_load_ts, df_loads], ignore_index=True)
 
             if feedin_names:
                 df_feedin = get_df_of_all_empty_ts(feedin_names, region)
-                save_ts(df_feedin, path_empty_ts_feedin)
+                all_feedin_ts = pd.concat([all_feedin_ts, df_feedin], ignore_index=True)
 
             if efficiency_names:
                 df_efficiencies = get_df_of_all_empty_ts(efficiency_names, region)
-                save_ts(df_efficiencies, path_empty_ts_efficiencies)
+                all_efficiencies_ts = pd.concat([all_efficiencies_ts, df_efficiencies], ignore_index=True)
+
+    ts_dict = {
+        "load": (load_names, all_load_ts, path_empty_load_ts),
+        "feedin": (feedin_names, all_feedin_ts, path_empty_ts_feedin),
+        "efficiency": (efficiency_names, all_efficiencies_ts, path_empty_ts_efficiencies),
+    }
+
+    for ts_type, (ts_name, ts_df, ts_path) in ts_dict.items():
+        if ts_name:
+            drop_duplicates(ts_df)
+            save_ts(ts_df, ts_path)

--- a/scripts/create_empty_ts.py
+++ b/scripts/create_empty_ts.py
@@ -126,7 +126,7 @@ def create_empty_ts(name):
     datetime_format = settings.create_empty_ts.datetime_format
 
     # Get start date from scenario specifications
-    start = datetime.strptime(scenario_specs["datetimeindex"]["start"], datetime_format)
+    start = datetime.strptime(scenario_specs["filter_timeseries"]["timeindex_start"], datetime_format)
 
     # Get periods and freq from scenario specifications
     periods = scenario_specs["datetimeindex"]["periods"]

--- a/scripts/create_empty_ts.py
+++ b/scripts/create_empty_ts.py
@@ -319,7 +319,7 @@ if __name__ == "__main__":
         ),
     }
 
-    for ts_type, (ts_name, ts_df, ts_path) in ts_dict.items():
+    for ts_type, (ts_name, ts_data, ts_path) in ts_dict.items():
         if ts_name:
-            drop_duplicates(ts_df)
-            save_ts(ts_df, ts_path)
+            drop_duplicates(ts_data)
+            save_ts(ts_data, ts_path)

--- a/scripts/create_empty_ts.py
+++ b/scripts/create_empty_ts.py
@@ -228,7 +228,7 @@ def save_ts(_df, path):
 
 
     """
-    if not os.path.exists(path):
+    if not os.path.exists(path) or settings.create_empty_ts.overwrite:
 
         _df.index.name = "id_ts"
 

--- a/scripts/create_empty_ts.py
+++ b/scripts/create_empty_ts.py
@@ -321,5 +321,5 @@ if __name__ == "__main__":
 
     for ts_type, (ts_name, ts_data, ts_path) in ts_dict.items():
         if ts_name:
-            drop_duplicates(ts_data)
+            ts_data = drop_duplicates(ts_data)
             save_ts(ts_data, ts_path)

--- a/scripts/create_empty_ts.py
+++ b/scripts/create_empty_ts.py
@@ -35,7 +35,7 @@ from oemof_b3 import model
 from oemof_b3.tools.data_processing import HEADER_B3_TS, stack_timeseries
 
 
-def get_sub_dict(subsub_key, dict):
+def get_sub_dict(subsub_key, _dict):
     """
     This function extracts a subsub-dictionary from a dictionary using a subsub-key
 
@@ -44,7 +44,7 @@ def get_sub_dict(subsub_key, dict):
     subsub_key : str
         Key of the subsub-dictionary
 
-    dict : dict
+    _dict : dict
         Dictionary with two inner dictionaries
 
     Outputs
@@ -56,7 +56,7 @@ def get_sub_dict(subsub_key, dict):
 
     subsub_dict = [
         subsubdict
-        for sub_dict in dict.values()
+        for sub_dict in _dict.values()
         for subsubdict in sub_dict.values()
         if subsub_key in subsubdict
     ]
@@ -123,10 +123,10 @@ def create_empty_ts(name):
         Dataframe containing ts with zeros as values and name as column name
 
     """
-    format = settings.create_empty_ts.datetime_format
+    datetime_format = settings.create_empty_ts.datetime_format
 
     # Get start date from scenario specifications
-    start = datetime.strptime(scenario_specs["datetimeindex"]["start"], format)
+    start = datetime.strptime(scenario_specs["datetimeindex"]["start"], datetime_format)
 
     # Get periods and freq from scenario specifications
     periods = scenario_specs["datetimeindex"]["periods"]
@@ -141,7 +141,7 @@ def create_empty_ts(name):
     return df
 
 
-def get_df_of_all_empty_ts(profile_names, region):
+def get_df_of_all_empty_ts(profile_names, _region):
     """
     This function provides a Dataframe with all ts of a profile (load, feedin
     or efficiency)
@@ -151,7 +151,7 @@ def get_df_of_all_empty_ts(profile_names, region):
     profile_names : list
         List with names of profiles (loads, feedins or efficiencies)
 
-    region : str
+    _region : str
         Region
 
     Outputs
@@ -172,7 +172,7 @@ def get_df_of_all_empty_ts(profile_names, region):
         stacked_df = stacked_df.reindex(columns=HEADER_B3_TS)
 
         # Add region and scenario_specs to Dataframe
-        stacked_df["region"] = region
+        stacked_df["region"] = _region
         stacked_df["scenario_key"] = settings.create_empty_ts.filter_ts
 
         # Append Dataframe to ts_profile_df and add index name

--- a/scripts/create_empty_ts.py
+++ b/scripts/create_empty_ts.py
@@ -64,7 +64,7 @@ def get_sub_dict(subsub_key, dict):
     return subsub_dict
 
 
-def set_ts_values(periods, date_rng, name):
+def create_empty_ts_with_zero_or_nan_values(periods, date_rng, name):
     """
     Returns a pandas DataFrame with time series values set to either zeros or
     NaNs, based on settings.yaml
@@ -99,8 +99,9 @@ def set_ts_values(periods, date_rng, name):
         )
     else:
         raise KeyError(
-            f"{ts_values} is not a valid option. "
-            f"Please provide a valid value for ts_values in settings.yaml"
+            f"{ts_values} is not a valid option. Valid options are: 'zeros' or"
+            f"'empty'. Please provide a valid value for ts_values in "
+            f"settings.yaml"
         )
 
     return df
@@ -135,7 +136,7 @@ def create_empty_ts(name):
     date_rng = pd.date_range(start=start, periods=periods, freq=freq)
 
     # Create DataFrame with ts of zeros from date range and name
-    df = set_ts_values(periods, date_rng, name)
+    df = create_empty_ts_with_zero_or_nan_values(periods, date_rng, name)
 
     return df
 

--- a/scripts/create_empty_ts.py
+++ b/scripts/create_empty_ts.py
@@ -1,0 +1,256 @@
+# coding: utf-8
+r"""
+Inputs
+-------
+scenarios_dir : str
+    ``scenarios``: path to scenarios directory
+destination : str
+    ``raw/time_series/empty_ts_efficiencies.csv``: path of output directory for
+    empty ts with efficiencies of all scenarios
+    ``raw/time_series/empty_ts_feedin.csv``: path of output directory for
+    empty ts with feedins of all scenarios
+    ``raw/time_series/empty_ts_load.csv``: path of output directory for
+    empty ts with loads of all scenarios
+
+Outputs
+---------
+pandas.DataFrame
+    Empty ts in oemof-B3 resource format.
+
+Description
+-------------
+The script creates empty DataFrames for load, feed-in and efficiency time
+series data that serve as template for input data.
+"""
+import sys
+import os
+import pandas as pd
+import numpy as np
+
+from datetime import datetime
+
+from oemof_b3.config.config import load_yaml, settings
+from oemof_b3.model import model_structures
+from oemof_b3 import model
+from oemof_b3.tools.data_processing import HEADER_B3_TS, stack_timeseries
+
+
+def get_sub_dict(subsub_key, dict):
+    """
+    This function extracts a subsub-dictionary from a dictionary using a subsub-key
+
+    Inputs
+    -------
+    subsub_key : str
+        Key of the subsub-dictionary
+
+    dict : dict
+        Dictionary with two inner dictionaries
+
+    Outputs
+    -------
+    subsub_dict : dictionary
+        Subsub-dictionary
+
+    """
+
+    subsub_dict = [
+        subsubdict
+        for sub_dict in dict.values()
+        for subsubdict in sub_dict.values()
+        if subsub_key in subsubdict
+    ]
+
+    return subsub_dict
+
+
+def set_ts_values(periods, date_rng, name):
+    """
+    Returns a pandas DataFrame with time series values set to either zeros or
+    NaNs, based on settings.yaml
+
+    Parameters
+    ----------
+    periods : int
+        Number of periods in the time series
+    date_rng : pd.DatetimeIndex
+        Datetime index specifying start and end dates of the time series
+    name : str
+        Name of the time series column in the DataFrame
+
+    Returns
+    -------
+    df : pd.DataFrame
+        A pandas DataFrame containing the time series values, with 'name' as
+        the column name.
+
+    Raises
+    ------
+    KeyError
+        If settings.create_empty_ts.ts_values is not set to either 'zeros' or 'empty'.
+    """
+    ts_values = settings.create_empty_ts.ts_values
+
+    if ts_values == "zeros":
+        df = pd.DataFrame(np.zeros((periods, 1)), index=date_rng, columns=[name])
+    elif ts_values == "empty":
+        df = pd.DataFrame(
+            np.empty((periods, 1)) * np.nan, index=date_rng, columns=[name]
+        )
+    else:
+        raise KeyError(
+            f"{ts_values} is not a valid option. "
+            f"Please provide a valid value for ts_values in settings.yaml"
+        )
+
+    return df
+
+
+def create_empty_ts(name):
+    """
+    This function provides a Dataframe with a time series of zeros
+    according to the start, periods and freq of the scenario specifications
+
+    Parameters
+    ----------
+    name : str
+        Name of the ts
+
+    Returns
+    -------
+    df : Dataframe
+        Dataframe containing ts with zeros as values and name as column name
+
+    """
+    format = settings.create_empty_ts.datetime_format
+
+    # Get start date from scenario specifications
+    start = datetime.strptime(scenario_specs["datetimeindex"]["start"], format)
+
+    # Get periods and freq from scenario specifications
+    periods = scenario_specs["datetimeindex"]["periods"]
+    freq = scenario_specs["datetimeindex"]["freq"]
+
+    # Get date range from start periods and freq
+    date_rng = pd.date_range(start=start, periods=periods, freq=freq)
+
+    # Create DataFrame with ts of zeros from date range and name
+    df = set_ts_values(periods, date_rng, name)
+
+    return df
+
+
+def get_df_of_all_empty_ts(profile_names, region):
+    """
+    This function provides a Dataframe with all ts of a profile (load, feedin
+    or efficiency)
+
+    Inputs
+    -------
+    profile_names : list
+        List with names of profiles (loads, feedins or efficiencies)
+
+    region : str
+        Region
+
+    Outputs
+    -------
+    ts_df : Dataframe
+        Dataframe with empty time series (consisting of zeros)
+
+    """
+    ts_df = pd.DataFrame(columns=HEADER_B3_TS)
+
+    for name in profile_names:
+        df = create_empty_ts(name)
+
+        # Stack Dataframe
+        stacked_df = stack_timeseries(df)
+
+        # Reindex according to time series in schema directory
+        stacked_df = stacked_df.reindex(columns=HEADER_B3_TS)
+
+        # Add region and scenario_specs to Dataframe
+        stacked_df["region"] = region
+        stacked_df["scenario_key"] = settings.create_empty_ts.filter_ts
+
+        # Append Dataframe to ts_profile_df and add index name
+        ts_df = pd.concat([ts_df, stacked_df], ignore_index=True)
+        ts_df.index.name = "id_ts"
+
+    return ts_df
+
+
+def save_ts(_df, path):
+    """
+    This function saves time series that contain values of datetime format
+    Datetime format used: "%Y-%m-%d %H:%M:%S"
+
+    Parameters
+    ----------
+    _df : Dataframe
+        Dataframe with value(s) of datetime format
+
+    path : str
+        Path where df is saved to
+
+
+    """
+    _df.to_csv(
+        path,
+        index=True,
+        date_format="%Y-%m-%d %H:%M:%S",
+        sep=settings.general.separator,
+    )
+
+
+if __name__ == "__main__":
+    scenarios_dir = sys.argv[1]
+
+    path_empty_load_ts = sys.argv[2]
+    path_empty_ts_feedin = sys.argv[3]
+    path_empty_ts_efficiencies = sys.argv[4]
+
+    scenarios = os.listdir(scenarios_dir)
+
+    for scenario_specs in scenarios:
+        scenario_specs = load_yaml(os.path.join(scenarios_dir, scenario_specs))
+        model_structure = model_structures[scenario_specs["model_structure"]]
+
+        component_attrs_update = load_yaml(
+            os.path.join(model.here, "component_attrs_update.yml")
+        )
+
+        # Get all foreign_keys that contain "profile" from component_attrs_update
+        foreign_keys_profile = get_sub_dict("profile", component_attrs_update)
+
+        # Get all foreign_keys that contain "efficiency" from component_attrs_update
+        foreign_keys_efficiency = get_sub_dict("efficiency", component_attrs_update)
+
+        # Save profile names depending on whether it is a load, a feed-in or an efficiency
+        load_names = [
+            attr_subdict["profile"]
+            for attr_subdict in foreign_keys_profile
+            if "demand" in attr_subdict["profile"]
+        ]
+        feedin_names = [
+            attr_subdict["profile"]
+            for attr_subdict in foreign_keys_profile
+            if not "demand" in attr_subdict["profile"]
+        ]
+        efficiency_names = [
+            attr_subdict["efficiency"] for attr_subdict in foreign_keys_efficiency
+        ]
+
+        for region in model_structure["regions"]:
+            if load_names:
+                df_loads = get_df_of_all_empty_ts(load_names, region)
+                save_ts(df_loads, path_empty_load_ts)
+
+            if feedin_names:
+                df_feedin = get_df_of_all_empty_ts(feedin_names, region)
+                save_ts(df_feedin, path_empty_ts_feedin)
+
+            if efficiency_names:
+                df_efficiencies = get_df_of_all_empty_ts(efficiency_names, region)
+                save_ts(df_efficiencies, path_empty_ts_efficiencies)

--- a/snakemake_rules/create_empty_scalars.smk
+++ b/snakemake_rules/create_empty_scalars.smk
@@ -1,4 +1,4 @@
 rule create_empty_scalars:
-    input: directory("scenarios/")
+    input: "scenarios/"
     output: "raw/scalars/empty_scalars.csv"
     shell: "python scripts/create_empty_scalars.py {input} {output}"

--- a/snakemake_rules/create_empty_ts.smk
+++ b/snakemake_rules/create_empty_ts.smk
@@ -1,0 +1,8 @@
+rule create_empty_ts:
+    input: directory("scenarios/")
+    output:
+        "raw/time_series/empty_ts_load.csv",
+        "raw/time_series/empty_ts_feedin.csv",
+        "raw/time_series/empty_ts_efficiencies.csv"
+
+    shell: "python scripts/create_empty_ts.py {input} {output[0]} {output[1]} {output[2]}"

--- a/snakemake_rules/create_empty_ts.smk
+++ b/snakemake_rules/create_empty_ts.smk
@@ -1,5 +1,5 @@
 rule create_empty_ts:
-    input: directory("scenarios/")
+    input: "scenarios/"
     output:
         "raw/time_series/empty_ts_load.csv",
         "raw/time_series/empty_ts_feedin.csv",


### PR DESCRIPTION
With this PR it is possible to create empty time series in the directory `raw/time_series`.

Empty means in this case, that the time series contain either "0" or "nan" as values. This can be set via `create_empty_ts.ts_values` in `settings.yaml`.

The docs have been updated.

To test the new functionality run:
```
snakemake -j1 create_empty_ts
```
Before you need to [install oemof-B3 according to docs](https://oemof-b3.readthedocs.io/en/latest/getting_started.html) and download raw directory with:

```
snakemake -j1 download_raw_data
```