### PR TITLE
Fix/unstacking warning cols

### DIFF
--- a/oemof_b3/tools/data_processing.py
+++ b/oemof_b3/tools/data_processing.py
@@ -1053,7 +1053,7 @@ def unstack_timeseries(df):
     lost_columns = ["source", "comment"]
     for col in lost_columns:
         if col in list(df.columns):
-            if not _df[col].isna().any() or _df[col].values.any() == "None":
+            if not _df[col].isna().all() or _df[col].values.all() == "None":
                 logger.warning(
                     f"Caution any remarks in column '{col}' are lost after unstacking."
                 )

--- a/oemof_b3/tools/data_processing.py
+++ b/oemof_b3/tools/data_processing.py
@@ -1053,9 +1053,10 @@ def unstack_timeseries(df):
     lost_columns = ["source", "comment"]
     for col in lost_columns:
         if col in list(df.columns):
-            logger.warning(
-                f"Caution any remarks in column '{col}' are lost after unstacking."
-            )
+            if not _df[col].isna().any() or _df[col].values.any() == "None":
+                logger.warning(
+                    f"Caution any remarks in column '{col}' are lost after unstacking."
+                )
 
     # Process values of series
     values_series = []

--- a/tests/_files/oemof_b3_resources_timeseries_stacked_comments.csv
+++ b/tests/_files/oemof_b3_resources_timeseries_stacked_comments.csv
@@ -1,0 +1,19 @@
+id_ts;region;var_name;timeindex_start;timeindex_stop;timeindex_resolution;series;var_unit;source;comment
+0;BB;biomass-st_out_electricity;2019-01-01 00:00:00;2019-01-01 02:00:00;H;[0.0, 0.0, 0.0];;;We have a comment here.
+1;BB;ch4-gt_out_electricity;2019-01-01 00:00:00;2019-01-01 02:00:00;H;[0.0, 0.0, 0.0];;;We have a comment here.
+2;BB;electricity-curtailment_in_electricity;2019-01-01 00:00:00;2019-01-01 02:00:00;H;[0.0, 0.0, 0.0];;;We have a comment here.
+3;BB;electricity-demand_in_electricity;2019-01-01 00:00:00;2019-01-01 02:00:00;H;[1889794.8071409904, 1870448.7801216468, 1803840.2010708163];;;We have a comment here.
+4;BB;electricity-liion-battery_in_electricity;2019-01-01 00:00:00;2019-01-01 02:00:00;H;[0.0, 0.0, 0.0];;;We have a comment here.
+5;BB;electricity-liion-battery_out_electricity;2019-01-01 00:00:00;2019-01-01 02:00:00;H;[882505.2, 1194379.0, 1289504.5];;;We have a comment here.
+6;BB;electricity-shortage_out_electricity;2019-01-01 00:00:00;2019-01-01 02:00:00;H;[0.0, 0.0, 0.0];;;We have a comment here.
+7;BB;solar-pv_out_electricity;2019-01-01 00:00:00;2019-01-01 02:00:00;H;[0.0, 0.0, 0.0];;;We have a comment here.
+8;BB;wind-onshore_out_electricity;2019-01-01 00:00:00;2019-01-01 02:00:00;H;[1145114.0, 801141.1, 595497.8];;;We have a comment here.
+9;BE;biomass-st_out_electricity;2019-01-01 00:00:00;2019-01-01 02:00:00;H;[0.0, 0.0, 0.0];;;We have a comment here.
+10;BE;ch4-gt_out_electricity;2019-01-01 00:00:00;2019-01-01 02:00:00;H;[0.0, 0.0, 0.0];;;We have a comment here.
+11;BE;electricity-curtailment_in_electricity;2019-01-01 00:00:00;2019-01-01 02:00:00;H;[0.0, 0.0, 0.0];;;We have a comment here.
+12;BE;electricity-demand_in_electricity;2019-01-01 00:00:00;2019-01-01 02:00:00;H;[1889794.8071409904, 1870448.7801216468, 1803840.2010708163];;;We have a comment here.
+13;BE;electricity-liion-battery_in_electricity;2019-01-01 00:00:00;2019-01-01 02:00:00;H;[0.0, 0.0, 0.0];;;We have a comment here.
+14;BE;electricity-liion-battery_out_electricity;2019-01-01 00:00:00;2019-01-01 02:00:00;H;[882505.2, 1194379.0, 1289504.5];;;We have a comment here.
+15;BE;electricity-shortage_out_electricity;2019-01-01 00:00:00;2019-01-01 02:00:00;H;[0.0, 0.0, 0.0];;;We have a comment here.
+16;BE;solar-pv_out_electricity;2019-01-01 00:00:00;2019-01-01 02:00:00;H;[0.0, 0.0, 0.0];;;We have a comment here.
+17;BE;wind-onshore_out_electricity;2019-01-01 00:00:00;2019-01-01 02:00:00;H;[1145114.0, 801141.1, 595497.8];;;We have a comment here.

--- a/tests/test_data_processing.py
+++ b/tests/test_data_processing.py
@@ -501,25 +501,33 @@ class test_unstack_warning_source_comment(unittest.TestCase):
     # Assert WARNING with unstack_timeseries(df_with_comments)
     def test_unstack_warning_source_comment(self):
         # Patch the logger.warning method to capture the warning calls
-        with patch('oemof_b3.tools.data_processing.logger.warning') as mock_logger_warning:
+        with patch(
+            "oemof_b3.tools.data_processing.logger.warning"
+        ) as mock_logger_warning:
             # Call the function with df_with_comments, which should raise a warning
             unstacked_df = unstack_timeseries(self.df_with_comments)
 
         # Check if the logger.warning was called with the expected messages
         expected_warnings = [
             "Caution any remarks in column 'source' are lost after unstacking.",
-            "Caution any remarks in column 'comment' are lost after unstacking."
+            "Caution any remarks in column 'comment' are lost after unstacking.",
         ]
 
         # Check if any of the expected warning messages are contained in the captured warning messages
-        self.assertTrue(any(
-            warning_msg in str(warning[0]) for warning in mock_logger_warning.call_args_list for warning_msg in
-            expected_warnings))
+        self.assertTrue(
+            any(
+                warning_msg in str(warning[0])
+                for warning in mock_logger_warning.call_args_list
+                for warning_msg in expected_warnings
+            )
+        )
 
     # Assert that unstack_timeseries(df_wo_comments) does not give the warning:
     def test_unstack_no_warning(self):
         # Patch the logger.warning method to capture the warning calls
-        with patch('oemof_b3.tools.data_processing.logger.warning') as mock_logger_warning:
+        with patch(
+            "oemof_b3.tools.data_processing.logger.warning"
+        ) as mock_logger_warning:
             # Call the function with df_wo_comments, which should not raise a warning
             unstacked_df = unstack_timeseries(self.df_wo_comments)
 
@@ -527,7 +535,7 @@ class test_unstack_warning_source_comment(unittest.TestCase):
         mock_logger_warning.assert_not_called()
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()
 
 

--- a/tests/test_data_processing.py
+++ b/tests/test_data_processing.py
@@ -515,12 +515,10 @@ class test_unstack_warning_source_comment(unittest.TestCase):
 
         # Check if any of the expected warning messages are contained
         # in the captured warning messages
+        warnings_called = [call[0][0] for call in mock_logger_warning.call_args_list]
+
         self.assertTrue(
-            any(
-                warning_msg in str(warning[0])
-                for warning in mock_logger_warning.call_args_list
-                for warning_msg in expected_warnings
-            )
+            any(warning_msg in warnings_called for warning_msg in expected_warnings)
         )
 
     # Assert that unstack_timeseries(df_wo_comments) does not give the warning:

--- a/tests/test_data_processing.py
+++ b/tests/test_data_processing.py
@@ -38,6 +38,7 @@ path_file_sc_update_scenarios_expected = full_path(
 )
 path_file_sc_mixed_types = full_path("oemof_b3_resources_scalars_mixed_types.csv")
 path_file_ts_stacked = full_path("oemof_b3_resources_timeseries_stacked.csv")
+path_file_ts_stacked_comments = full_path("oemof_b3_resources_timeseries_stacked_comments.csv")
 path_oemof_results_flows = full_path("oemof_results_flows.csv")
 path_oemof_b3_results_timeseries_flows = full_path(
     "oemof_b3_results_timeseries_flows.csv"
@@ -480,6 +481,21 @@ def test_unstack_stack_scalars_on_example_data():
     df_stacked = stack_var_name(df_unstacked)
 
     assert pd.testing.assert_frame_equal(df, df_stacked) is None
+
+
+def test_unstack_warning_source_comment(capfd):
+    df_wo_comments = load_b3_timeseries(path_file_ts_stacked)
+    df_with_comments = load_b3_timeseries(path_file_ts_stacked_comments)
+
+    # TODO: Assert that unstack_timeseries(df_wo_comments) does not give the warning:
+    # "Caution any remarks in column 'comments' are lost after unstacking."
+    # TODO: When the following is executed:
+    unstack_timeseries(df_wo_comments)
+
+    # TODO: Assert WARNING with unstack_timeseries(df_with_comments):
+    # "WARNING - Caution any remarks in column 'comments' are lost after unstacking."
+    # TODO: When the following is executed:
+    unstack_timeseries(df_with_comments)
 
 
 def test_merge_a_into_b():

--- a/tests/test_data_processing.py
+++ b/tests/test_data_processing.py
@@ -2,8 +2,6 @@ import os
 import numpy as np
 import pandas as pd
 import pytest
-import unittest
-import warnings
 
 from oemof_b3.tools.data_processing import (
     HEADER_B3_SCAL,

--- a/tests/test_data_processing.py
+++ b/tests/test_data_processing.py
@@ -2,8 +2,6 @@ import os
 import numpy as np
 import pandas as pd
 import pytest
-import unittest
-from unittest.mock import patch
 
 from oemof_b3.tools.data_processing import (
     HEADER_B3_SCAL,
@@ -487,48 +485,24 @@ def test_unstack_stack_scalars_on_example_data():
     assert pd.testing.assert_frame_equal(df, df_stacked) is None
 
 
-class test_unstack_warning_source_comment(unittest.TestCase):
+def test_unstack_warning_source_comment():
     """
     This test verifies whether the caution message is appropriately raised
     when executing the function unstack_timeseries(). The caution message will
     be raised if source and comments are not empty.
     """
+    df_wo_comments = load_b3_timeseries(path_file_ts_stacked)
+    df_with_comments = load_b3_timeseries(path_file_ts_stacked_comments)
 
-    def setUp(self):
-        self.df_with_comments = load_b3_timeseries(path_file_ts_stacked_comments)
-        self.df_wo_comments = load_b3_timeseries(path_file_ts_stacked)
+    # TODO: Assert that unstack_timeseries(df_wo_comments) does not give the warning:
+    # "Caution any remarks in column 'comments' are lost after unstacking."
+    # TODO: When the following is executed:
+    unstack_timeseries(df_wo_comments)
 
-    # Assert WARNING with unstack_timeseries(df_with_comments)
-    def test_unstack_warning_source_comment(self):
-        # Patch the logger.warning method to capture the warning calls
-        with patch('oemof_b3.tools.data_processing.logger.warning') as mock_logger_warning:
-            # Call the function with df_with_comments, which should raise a warning
-            unstacked_df = unstack_timeseries(self.df_with_comments)
-
-        # Check if the logger.warning was called with the expected messages
-        expected_warnings = [
-            "Caution any remarks in column 'source' are lost after unstacking.",
-            "Caution any remarks in column 'comment' are lost after unstacking."
-        ]
-
-        # Check if any of the expected warning messages are contained in the captured warning messages
-        self.assertTrue(any(
-            warning_msg in str(warning[0]) for warning in mock_logger_warning.call_args_list for warning_msg in
-            expected_warnings))
-
-    # Assert that unstack_timeseries(df_wo_comments) does not give the warning:
-    def test_unstack_no_warning(self):
-        # Patch the logger.warning method to capture the warning calls
-        with patch('oemof_b3.tools.data_processing.logger.warning') as mock_logger_warning:
-            # Call the function with df_wo_comments, which should not raise a warning
-            unstacked_df = unstack_timeseries(self.df_wo_comments)
-
-        # Check that logger.warning was not called in this case
-        mock_logger_warning.assert_not_called()
-
-
-if __name__ == '__main__':
-    unittest.main()
+    # TODO: Assert WARNING with unstack_timeseries(df_with_comments):
+    # "WARNING - Caution any remarks in column 'comments' are lost after unstacking."
+    # TODO: When the following is executed:
+    unstack_timeseries(df_with_comments)
 
 
 def test_merge_a_into_b():

--- a/tests/test_data_processing.py
+++ b/tests/test_data_processing.py
@@ -505,7 +505,7 @@ class test_unstack_warning_source_comment(unittest.TestCase):
             "oemof_b3.tools.data_processing.logger.warning"
         ) as mock_logger_warning:
             # Call the function with df_with_comments, which should raise a warning
-            unstacked_df = unstack_timeseries(self.df_with_comments)
+            unstack_timeseries(self.df_with_comments)
 
         # Check if the logger.warning was called with the expected messages
         expected_warnings = [
@@ -513,7 +513,8 @@ class test_unstack_warning_source_comment(unittest.TestCase):
             "Caution any remarks in column 'comment' are lost after unstacking.",
         ]
 
-        # Check if any of the expected warning messages are contained in the captured warning messages
+        # Check if any of the expected warning messages are contained
+        # in the captured warning messages
         self.assertTrue(
             any(
                 warning_msg in str(warning[0])
@@ -529,7 +530,7 @@ class test_unstack_warning_source_comment(unittest.TestCase):
             "oemof_b3.tools.data_processing.logger.warning"
         ) as mock_logger_warning:
             # Call the function with df_wo_comments, which should not raise a warning
-            unstacked_df = unstack_timeseries(self.df_wo_comments)
+            unstack_timeseries(self.df_wo_comments)
 
         # Check that logger.warning was not called in this case
         mock_logger_warning.assert_not_called()

--- a/tests/test_data_processing.py
+++ b/tests/test_data_processing.py
@@ -38,7 +38,9 @@ path_file_sc_update_scenarios_expected = full_path(
 )
 path_file_sc_mixed_types = full_path("oemof_b3_resources_scalars_mixed_types.csv")
 path_file_ts_stacked = full_path("oemof_b3_resources_timeseries_stacked.csv")
-path_file_ts_stacked_comments = full_path("oemof_b3_resources_timeseries_stacked_comments.csv")
+path_file_ts_stacked_comments = full_path(
+    "oemof_b3_resources_timeseries_stacked_comments.csv"
+)
 path_oemof_results_flows = full_path("oemof_results_flows.csv")
 path_oemof_b3_results_timeseries_flows = full_path(
     "oemof_b3_results_timeseries_flows.csv"

--- a/tests/test_data_processing.py
+++ b/tests/test_data_processing.py
@@ -486,6 +486,11 @@ def test_unstack_stack_scalars_on_example_data():
 
 
 def test_unstack_warning_source_comment():
+    """
+    This test checks whether oemof-B3 scalars columns source and comments
+    are empty before unstacking. A caution message will be raised if source and comments are
+    not empty.
+    """
     df_wo_comments = load_b3_timeseries(path_file_ts_stacked)
     df_with_comments = load_b3_timeseries(path_file_ts_stacked_comments)
 
@@ -499,6 +504,7 @@ def test_unstack_warning_source_comment():
     # TODO: When the following is executed:
     unstack_timeseries(df_with_comments)
 
+test_unstack_warning_source_comment()
 
 def test_merge_a_into_b():
     r"""

--- a/tests/test_data_processing.py
+++ b/tests/test_data_processing.py
@@ -2,6 +2,8 @@ import os
 import numpy as np
 import pandas as pd
 import pytest
+import unittest
+import warnings
 
 from oemof_b3.tools.data_processing import (
     HEADER_B3_SCAL,
@@ -487,9 +489,9 @@ def test_unstack_stack_scalars_on_example_data():
 
 def test_unstack_warning_source_comment():
     """
-    This test checks whether oemof-B3 scalars columns source and comments
-    are empty before unstacking. A caution message will be raised if source and comments are
-    not empty.
+    This test verifies whether the caution message is appropriately raised
+    when executing the function unstack_timeseries(). The caution message will
+    be raised if source and comments are not empty.
     """
     df_wo_comments = load_b3_timeseries(path_file_ts_stacked)
     df_with_comments = load_b3_timeseries(path_file_ts_stacked_comments)
@@ -503,6 +505,7 @@ def test_unstack_warning_source_comment():
     # "WARNING - Caution any remarks in column 'comments' are lost after unstacking."
     # TODO: When the following is executed:
     unstack_timeseries(df_with_comments)
+
 
 def test_merge_a_into_b():
     r"""

--- a/tests/test_data_processing.py
+++ b/tests/test_data_processing.py
@@ -485,7 +485,7 @@ def test_unstack_stack_scalars_on_example_data():
     assert pd.testing.assert_frame_equal(df, df_stacked) is None
 
 
-def test_unstack_warning_source_comment(capfd):
+def test_unstack_warning_source_comment():
     df_wo_comments = load_b3_timeseries(path_file_ts_stacked)
     df_with_comments = load_b3_timeseries(path_file_ts_stacked_comments)
 

--- a/tests/test_data_processing.py
+++ b/tests/test_data_processing.py
@@ -504,8 +504,6 @@ def test_unstack_warning_source_comment():
     # TODO: When the following is executed:
     unstack_timeseries(df_with_comments)
 
-test_unstack_warning_source_comment()
-
 def test_merge_a_into_b():
     r"""
     Tests merge function.


### PR DESCRIPTION
Resolves #332

With this PR the logging warning `Caution any remarks in column '{col}' are lost after unstacking.` is only printed if column `source` or `comment` is not empty.

Open ToDos:

- [ ] Adjust the tests to check if the warning appears if the source or comment column is not empty and omits if they are empty.