### PR TITLE
Fix by adapting output path handling

### DIFF
--- a/scripts/plot_conv_pp_scalars.py
+++ b/scripts/plot_conv_pp_scalars.py
@@ -169,4 +169,7 @@ if __name__ == "__main__":
     # TODO: Check if oemoflex' function can be imported and used here
     plot_grouped_bar(ax, df_pivot, COLORS, UNIT)
 
-    plt.savefig(target + config.settings.general.plot_filetype, bbox_inches="tight")
+    # Create the target path according to file type set in settings
+    target_path = target.split(".")[0] + config.settings.general.plot_filetype
+
+    plt.savefig(target_path, bbox_inches="tight")


### PR DESCRIPTION
Resolves #303

The file type is added twice to the file name and hence the output can never be build by snakemake. With this commit the file path is set according to the file type in the settings.

This PR fixes the issue. Is only working with changes in PR https://github.com/rl-institut/oemof-B3/pull/336.